### PR TITLE
Add Deco Device as additional attribute for zone-presence information

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Besides the device being present (connected to the router), the following attrib
 | interface            | main, guest                      |
 | down_kilobytes_per_s | 100                              |
 | up_kilobytes_per_s   | 100                              |
-| deco_devic           | living_room                      |
+| deco_device          | living_room                      |
 
 {% if not installed %}
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Besides the device being present (connected to the router), the following attrib
 | interface            | main, guest                      |
 | down_kilobytes_per_s | 100                              |
 | up_kilobytes_per_s   | 100                              |
+| deco_devic           | living_room                      |
 
 {% if not installed %}
 

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -121,7 +121,7 @@ class TplinkDecoApi:
             await self.async_login()
 
         # First retrieve the list of devices
-        device_list_payload = {"operation": "read", "params": {"device_mac": "default"}}
+        device_list_payload = {"operation": "read"}
         response_json = await self._async_post(
             "List Devices",
             f"http://{self.host}/cgi-bin/luci/;stok={self._stok}/admin/device",

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -134,7 +134,7 @@ class TplinkDecoApi:
             raise Exception(f"List devices error {error_code}")
 
         # Store the devices in dict based on mac address
-        deco_devices = {x["mac"]:x["nickname"] for x in data["result"]["device_list"]}
+        deco_devices = {x["mac"]: x["nickname"] for x in data["result"]["device_list"]}
 
         clients = {}
         for deco_mac, deco_name in deco_devices.items():

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -38,6 +38,7 @@ class TPLinkDecoClient:
         self.interface = None
         self.down_kilobytes_per_s = 0
         self.up_kilobytes_per_s = 0
+        self.deco_device = None
         self.last_activity = None
 
     def update(
@@ -52,6 +53,7 @@ class TPLinkDecoClient:
         self.interface = data["interface"]
         self.down_kilobytes_per_s = bytes_to_bits(data["down_speed"])
         self.up_kilobytes_per_s = bytes_to_bits(data["up_speed"])
+        self.deco_device = data["deco_device"]
         self.last_activity = utc_point_in_time
 
 

--- a/custom_components/tplink_deco/device_tracker.py
+++ b/custom_components/tplink_deco/device_tracker.py
@@ -24,6 +24,7 @@ ATTR_CONNECTION_TYPE = "connection_type"
 ATTR_DOWN_KILOBYTES_PER_S = "down_kilobytes_per_s"
 ATTR_INTERFACE = "interface"
 ATTR_UP_KILOBYTES_PER_S = "up_kilobytes_per_s"
+ATTR_DECO_DEVICE = "deco_device"
 
 
 async def async_setup_entry(
@@ -128,6 +129,7 @@ class TplinkDecoDeviceTracker(CoordinatorEntity, RestoreEntity, ScannerEntity):
             ATTR_INTERFACE: self._attr_interface,
             ATTR_DOWN_KILOBYTES_PER_S: self._client.down_kilobytes_per_s,
             ATTR_UP_KILOBYTES_PER_S: self._client.up_kilobytes_per_s,
+            ATTR_DECO_DEVICE: self._client.deco_device,
         }
 
     @property


### PR DESCRIPTION
Instead of querying all connected clients for the complete mesh network, this modification will first query which deco devices exist and then query the clients per deco device.

For each client, we add the deco device name as an additional attribute (deco_device) such that you can use this integration also for room-presence detection.

Per refresh-loop, maybe one call could be removed if somehow we would cache the deco devices instead of requesting them. 

This feature is also referred to in issue #17 