### PR TITLE
Fix relative link to contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you prefer new entities to be disabled by default:
 
 ## Contributions are welcome!
 
-If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
+If you want to contribute to this please read the [Contribution guidelines](https://github.com/amosyuen/ha-tplink-deco/blob/master/CONTRIBUTING.md)
 
 ## Credits
 


### PR DESCRIPTION
Custom component information screen within HACS on a Home Assistant instance will open this link wrong.