### PR TITLE
Migrate async_forward_entry_setup to async_forward_entry_setups

### DIFF
--- a/custom_components/tplink_deco/__init__.py
+++ b/custom_components/tplink_deco/__init__.py
@@ -162,10 +162,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     hass.data[DOMAIN][config_entry.entry_id] = data
     deco_coordinator = data[COORDINATOR_DECOS_KEY]
 
-    for platform in PLATFORMS:
-        config_entry.async_create_task(
-            hass, hass.config_entries.async_forward_entry_setup(config_entry, platform)
-        )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    )
 
     async def async_reboot_deco(service: ServiceCall) -> None:
         dr = device_registry.async_get(hass=hass)


### PR DESCRIPTION
Fixes use of deprecated function that will stop this integration working in future versions of home assistant
Closes https://github.com/amosyuen/ha-tplink-deco/issues/309