### PR TITLE
Fix config flow could not be loaded

### DIFF
--- a/custom_components/tplink_deco/config_flow.py
+++ b/custom_components/tplink_deco/config_flow.py
@@ -210,7 +210,7 @@ class TplinkDecoOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry):
         """Initialize HACS options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self.data = dict(config_entry.data)
         self._errors = {}
 


### PR DESCRIPTION
Type: Bug Fix

Addresses the change in HA 2025.2 which broke the configuration page with error: "Config flow could not be loaded: 500 Internal Server Error Server got itself in trouble"

Related to Issue #454 

Tested as working on my HA Instance running 2026.1.2 