### PR TITLE
Fix presence flickering from per-node client fetch failures

### DIFF
--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .api import TplinkDecoApi
@@ -236,6 +237,23 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         # Must happen after super().__init__
         self.data = {} if data is None else data
 
+    async def _async_fetch_clients_for_deco(self, deco_mac):
+        """Fetch clients for a single deco, returning (deco_mac, client_list) or (deco_mac, None)."""
+        try:
+            clients = await async_call_and_propagate_config_error(
+                self.api.async_list_clients, deco_mac
+            )
+            return (deco_mac, clients)
+        except ConfigEntryAuthFailed:
+            raise
+        except Exception as err:
+            _LOGGER.warning(
+                "_async_update_data: Failed to get clients for deco %s: %s",
+                deco_mac,
+                err,
+            )
+            return (deco_mac, None)
+
     async def _async_update_data(self):
         """Update data via api."""
         if len(self._deco_update_coordinator.data.decos) == 0:
@@ -244,40 +262,46 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         old_clients = self.data
         clients = {}
         client_added = False
-        # List clients for all decos if _deco_update_coordinator is not provided
         deco_macs = self._deco_update_coordinator.data.decos.keys()
         utc_point_in_time = dt_util.utcnow()
-        # Send list client requests in parallel for each deco
 
-        deco_client_responses = await asyncio.gather(
-            *[
-                async_call_and_propagate_config_error(
-                    self.api.async_list_clients, deco_mac
-                )
-                for deco_mac in deco_macs
-            ]
+        # Send list client requests in parallel for each deco
+        results = await asyncio.gather(
+            *[self._async_fetch_clients_for_deco(mac) for mac in deco_macs]
         )
 
-        if len(deco_client_responses) > 0:
-            # deco_macs is not subscriptable, must be iterated
-            for deco_mac, deco_clients in zip(deco_macs, deco_client_responses):
-                for deco_client in deco_clients:
-                    client_mac = deco_client["mac"]
-                    client = old_clients.get(client_mac)
-                    if client is None:
-                        client_added = True
-                        client = TpLinkDecoClient(client_mac)
-                        _LOGGER.debug(
-                            "_async_update_data: Found new client mac=%s", client.mac
-                        )
-                    client.update(deco_client, deco_mac, utc_point_in_time)
-                    clients[client_mac] = client
+        failed_deco_macs = set()
+        successful_count = 0
+        for deco_mac, deco_clients in results:
+            if deco_clients is None:
+                failed_deco_macs.add(deco_mac)
+                continue
+            successful_count += 1
+            for deco_client in deco_clients:
+                client_mac = deco_client["mac"]
+                client = old_clients.get(client_mac)
+                if client is None:
+                    client_added = True
+                    client = TpLinkDecoClient(client_mac)
+                    _LOGGER.debug(
+                        "_async_update_data: Found new client mac=%s", client.mac
+                    )
+                client.update(deco_client, deco_mac, utc_point_in_time)
+                clients[client_mac] = client
+
+        if successful_count == 0 and len(failed_deco_macs) > 0:
+            raise UpdateFailed(
+                f"All {len(failed_deco_macs)} deco nodes failed to respond"
+            )
 
         # Copy over clients no longer online
         for client in old_clients.values():
             mac = client.mac
             if mac not in clients:
                 clients[mac] = client
+                if client.deco_mac in failed_deco_macs:
+                    # Node was unreachable; preserve client state as-is
+                    continue
                 if client.last_activity is None:
                     client.online = False
                 else:


### PR DESCRIPTION
## Summary

Fixes #482

The existing `asyncio.gather` in `TplinkDecoClientUpdateCoordinator._async_update_data()` fails the entire client update when any single Deco node returns an error (500, timeout, connection refused). This causes all device trackers to go `unavailable`, triggering false "away" events in presence-based automations.

### Changes

- **Added `_async_fetch_clients_for_deco()` wrapper** — catches per-node errors individually instead of letting one failure blow up the entire `asyncio.gather`. `ConfigEntryAuthFailed` is still propagated immediately.
- **Track `failed_deco_macs`** — distinguishes between nodes that responded successfully vs those that errored.
- **Preserve client state for unreachable nodes** — when a node fails but others succeed, clients last seen on the failed node keep their previous online/offline state and `last_activity` timestamp, rather than being marked offline.
- **`UpdateFailed` only on total failure** — only raised when ALL nodes fail to respond, not when a single node has issues.

### Testing

This patch has been running in production for over a month on a 2-node Deco BE63 mesh (firmware 1.2.10). During that period:
- ~1,000+ per-node 500 errors were handled gracefully (logged as warnings, state preserved)
- Presence detection remained stable despite one node being consistently flaky
- The only `UpdateFailed` events occurred during actual full router outages (connection refused on all nodes)

### Related issues

- #39 — unavailable state for all DECO devices
- #95 — option to keep last state instead of becoming unavailable
- #276 — devices not reporting as on network
- #294 — unexpected error fetching client data