### PR TITLE
Fix Home Assistant 2026.4 compatibility and add diagnostic entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# TP-Link Deco (Community Fix)
+
+⚠️ This fork contains a fix for Home Assistant 2026.4 compatibility.
+
+The original repository is in maintenance mode and no longer actively tested.
+This fork restores functionality for newer Home Assistant versions.
+
+## Status
+
+- ✅ Works on Home Assistant 2026.4.x
+- ✅ Integration loads correctly
+- ✅ Device updates working
+
+👉 Use this fork if the original integration no longer works.
+
 # TP-Link Deco
 
 [![GitHub Release][releases-shield]][releases]

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -399,8 +399,16 @@ class TplinkDecoApi:
         data: Any,
     ) -> dict:
         headers = {CONTENT_TYPE: "application/json"}
+        # Gebruik een dictionary voor cookies in plaats van een string in headers
+        request_cookies = {}
         if self._cookie is not None:
-            headers[COOKIE] = self._cookie
+            try:
+                # Split 'sysauth=abc' naar {'sysauth': 'abc'}
+                cookie_parts = self._cookie.split("=", 1)
+                if len(cookie_parts) == 2:
+                    request_cookies[cookie_parts[0]] = cookie_parts[1]
+            except Exception:
+                _LOGGER.warning("Could not parse cookie: %s", self._cookie)
         try:
             async with async_timeout.timeout(self._timeout_seconds):
                 response = await self._session.post(
@@ -408,22 +416,23 @@ class TplinkDecoApi:
                     params=params,
                     data=data,
                     headers=headers,
+                    cookies=request_cookies, # Gebruik de cookies parameter
                     ssl=self._ssl_context,
                 )
                 response.raise_for_status()
 
-                cookie = response.headers.get(SET_COOKIE)
-                if cookie is not None:
-                    match = re.search(r"(sysauth=[a-f0-9]+)", cookie)
+                # Verbeterde extractie: loop door alle Set-Cookie headers
+                for cookie_header in response.headers.getall(SET_COOKIE, []):
+                    match = re.search(r"(sysauth=[a-f0-9]+)", cookie_header)
                     if match:
                         self._cookie = match.group(1)
-                        _LOGGER.debug("cookie=%s", self._cookie)
+                        _LOGGER.debug("Found new cookie: %s", self._cookie)
+                        break
 
-                # Sometimes server responses with incorrect content type, so disable the check
+                # Soms antwoordt de server met de verkeerde content-type
                 response_json = await response.json(content_type=None)
                 if "error_code" in response_json:
                     error_code = response_json.get("error_code")
-
                     if error_code != 0 and error_code != "":
                         _LOGGER.debug(
                             "%s error_code=%s, response_json=%s",

--- a/custom_components/tplink_deco/binary_sensor.py
+++ b/custom_components/tplink_deco/binary_sensor.py
@@ -1,0 +1,132 @@
+"""Binary sensors for TP-Link Deco."""
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import COORDINATOR_DECOS_KEY
+from .const import DOMAIN
+from .const import SIGNAL_DECO_ADDED
+from .coordinator import TpLinkDeco
+from .coordinator import TplinkDecoUpdateCoordinator
+from .device import create_device_info
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+):
+    """Set up binary sensor platform."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator_decos = data[COORDINATOR_DECOS_KEY]
+
+    tracked_decos = set()
+
+    def add_binary_sensors_for_deco(deco: TpLinkDeco) -> None:
+        async_add_entities(
+            [
+                TplinkDecoInternetOnlineBinarySensor(
+                    coordinator_decos,
+                    deco.mac,
+                ),
+                TplinkDecoOnlineBinarySensor(
+                    coordinator_decos,
+                    deco.mac,    
+                ),
+            ]
+        )
+
+    def add_untracked_deco_binary_sensors():
+        """Add binary sensors for newly discovered decos."""
+        for mac, deco in coordinator_decos.data.decos.items():
+            if mac in tracked_decos:
+                continue
+
+            add_binary_sensors_for_deco(deco)
+            tracked_decos.add(mac)
+
+    add_untracked_deco_binary_sensors()
+
+    coordinator_decos.on_close(
+        async_dispatcher_connect(
+            hass, SIGNAL_DECO_ADDED, add_untracked_deco_binary_sensors
+        )
+    )
+
+
+class TplinkDecoInternetOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """TP-Link Deco internet online binary sensor."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Internet online"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator_decos: TplinkDecoUpdateCoordinator,
+        deco_mac: str,
+    ) -> None:
+        super().__init__(coordinator_decos)
+        self._deco_mac = deco_mac
+        self._attr_unique_id = f"{deco_mac}_internet_online"
+
+    @property
+    def _deco(self) -> TpLinkDeco:
+        """Return current deco object."""
+        return self.coordinator.data.decos[self._deco_mac]
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if internet is online."""
+        value = self._deco.internet_online
+
+        if isinstance(value, str):
+            return value.lower() in ("online", "true", "1", "yes")
+        
+        return bool(value)
+    
+    @property
+    def available(self) -> bool:
+        return self._deco is not None and self._deco.internet_online is not None
+
+
+    @property
+    def device_info(self):
+        """Return device info."""
+        return create_device_info(
+            self._deco,
+            self.coordinator.data.master_deco,
+        )
+
+class TplinkDecoOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity):
+    """TP-Link Deco online (mesh/backhaul) status."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Deco online"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator_decos, deco_mac):
+        super().__init__(coordinator_decos)
+        self._deco_mac = deco_mac
+        self._attr_unique_id = f"{deco_mac}_online"
+
+    @property
+    def _deco(self):
+        return self.coordinator.data.decos[self._deco_mac]
+
+    @property
+    def is_on(self):
+        return bool(self._deco.online)
+
+    @property
+    def available(self):
+        return self._deco is not None
+
+    @property
+    def device_info(self):
+        return create_device_info(
+            self._deco,
+            self.coordinator.data.master_deco,
+        )

--- a/custom_components/tplink_deco/const.py
+++ b/custom_components/tplink_deco/const.py
@@ -1,5 +1,6 @@
 """Constants for TP-Link Deco."""
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.device_tracker.const import (
     DEFAULT_CONSIDER_HOME as DEFAULT_CONSIDER_HOME_SPAN,
@@ -54,4 +55,4 @@ SIGNAL_DECO_ADDED = f"{DOMAIN}-deco-added"
 SERVICE_REBOOT_DECO = "reboot_deco"
 
 # Platforms
-PLATFORMS = [DEVICE_TRACKER_DOMAIN, SENSOR_DOMAIN]
+PLATFORMS = [DEVICE_TRACKER_DOMAIN, SENSOR_DOMAIN, BINARY_SENSOR_DOMAIN]

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -75,7 +75,7 @@ class TpLinkDeco:
 
     def update(
         self,
-        data: dict[str:Any],
+        data: dict[str, Any],
     ) -> None:
         self.hw_version = data.get("hardware_ver")
         self.sw_version = data.get("software_ver")
@@ -86,7 +86,13 @@ class TpLinkDeco:
             self.name = snake_case_to_title_space(data.get("nickname"))
         self.ip_address = filter_invalid_ip(data.get("device_ip"))
         self.online = data.get("group_status") == "connected"
-        self.internet_online = data.get("inet_status") == "online"
+        inet = data.get("inet_status")
+        if inet is None:
+            self.internet_online = None
+        elif isinstance(inet, str):
+            self.internet_online = inet.lower() in ("online", "connected", "up")
+        else:
+            self.internet_online = bool(inet)    
         self.master = data.get("role") == "master"
         self.connection_type = data.get("connection_type")
         self.bssid_band2_4 = data.get("bssid_2g")

--- a/custom_components/tplink_deco/sensor.py
+++ b/custom_components/tplink_deco/sensor.py
@@ -1,11 +1,15 @@
 """TP-Link Deco."""
 
 import logging
+from dataclasses import dataclass
+from typing import Callable
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.sensor.const import SensorDeviceClass
 from homeassistant.components.sensor.const import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.const import UnitOfDataRate
 from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
@@ -25,6 +29,49 @@ from .device import create_device_info
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, kw_only=True)
+class TplinkDecoDiagnosticSensorDescription(SensorEntityDescription):
+    """Description of a TP-Link Deco diagnostic sensor."""
+
+    value_fn: Callable[[TpLinkDeco], str | None]
+
+
+DIAGNOSTIC_SENSOR_DESCRIPTIONS: tuple[TplinkDecoDiagnosticSensorDescription, ...] = (
+    TplinkDecoDiagnosticSensorDescription(
+        key="ip_address",
+        name="IP address",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda deco: deco.ip_address,
+    ),
+    TplinkDecoDiagnosticSensorDescription(
+        key="bssid_2_4ghz",
+        name="BSSID 2.4 GHz",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda deco: deco.bssid_band2_4,
+    ),
+    TplinkDecoDiagnosticSensorDescription(
+        key="bssid_5ghz",
+        name="BSSID 5 GHz",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda deco: deco.bssid_band5,
+    ),
+    TplinkDecoDiagnosticSensorDescription(
+        key="connection_type",
+        name="Backhaul type",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda deco: (
+            deco.connection_type[0]
+            if isinstance(deco.connection_type, list) and deco.connection_type
+            else deco.connection_type
+        ),
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
@@ -42,34 +89,57 @@ async def async_setup_entry(
             if deco is None
             else deco.mac
         )
-        async_add_entities(
-            [
-                TplinkTotalClientDataRateSensor(
+
+        entities = [
+            TplinkTotalClientDataRateSensor(
+                coordinator_decos,
+                coordinator_clients,
+                f"{name_prefix} Down",
+                f"{unique_id_prefix}_down",
+                "down_kilobytes_per_s",
+                deco,
+            ),
+            TplinkTotalClientDataRateSensor(
+                coordinator_decos,
+                coordinator_clients,
+                f"{name_prefix} Up",
+                f"{unique_id_prefix}_up",
+                "up_kilobytes_per_s",
+                deco,
+            ),
+        ]
+
+
+        if deco is not None:
+            entities.append(
+                TplinkDecoClientCountSensor(
                     coordinator_decos,
                     coordinator_clients,
-                    f"{name_prefix} Down",
-                    f"{unique_id_prefix}_down",
-                    "down_kilobytes_per_s",
-                    deco,
-                ),
-                TplinkTotalClientDataRateSensor(
-                    coordinator_decos,
-                    coordinator_clients,
-                    f"{name_prefix} Up",
-                    f"{unique_id_prefix}_up",
-                    "up_kilobytes_per_s",
-                    deco,
-                ),
-            ]
-        )
+                    deco.mac,
+                )
+            )
+
+            for description in DIAGNOSTIC_SENSOR_DESCRIPTIONS:
+                value = description.value_fn(deco)
+
+                if value is None or value == "" or value == []:
+                    continue
+
+                entities.append(
+                    TplinkDecoDiagnosticSensor(
+                        coordinator_decos,
+                        deco.mac,
+                        description,
+                    )
+                )
+
+        async_add_entities(entities)
 
     tracked_decos = set()
 
     @callback
     def add_untracked_deco_sensors():
-        """Add new tracker entities for clients."""
-        new_entities = []
-
+        """Add new tracker entities for decos."""
         for mac, deco in coordinator_decos.data.decos.items():
             if mac in tracked_decos:
                 continue
@@ -80,10 +150,7 @@ async def async_setup_entry(
             add_sensors_for_deco(deco)
             tracked_decos.add(mac)
 
-        if new_entities:
-            async_add_entities(new_entities)
-
-    add_sensors_for_deco(None)  # Total
+    add_sensors_for_deco(None)  # Total sensors
     add_untracked_deco_sensors()
 
     coordinator_decos.on_close(
@@ -92,7 +159,7 @@ async def async_setup_entry(
 
 
 class TplinkTotalClientDataRateSensor(CoordinatorEntity, SensorEntity):
-    """TP Link Total Client Data Rate Sensor Entity."""
+    """TP-Link total client data rate sensor entity."""
 
     def __init__(
         self,
@@ -113,7 +180,7 @@ class TplinkTotalClientDataRateSensor(CoordinatorEntity, SensorEntity):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_unique_id = unique_id
         super().__init__(coordinator_clients)
-        self._update_state()  # Must happen after init
+        self._update_state()
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -139,3 +206,80 @@ class TplinkTotalClientDataRateSensor(CoordinatorEntity, SensorEntity):
             if self._deco is None or client.deco_mac == self._deco.mac:
                 state += getattr(client, self._client_attribute)
         self._attr_native_value = state
+
+class TplinkDecoClientCountSensor(CoordinatorEntity, SensorEntity):
+    """TP-Link Deco connected client count sensor."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Connected clients"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self,
+        coordinator_decos: TplinkDecoUpdateCoordinator,
+        coordinator_clients: TplinkDecoClientUpdateCoordinator,
+        deco_mac: str,
+    ) -> None:
+        self._coordinator_decos = coordinator_decos
+        self._deco_mac = deco_mac
+        self._attr_unique_id = f"{deco_mac}_client_count"
+        super().__init__(coordinator_clients)
+        self._update_state()
+
+    @property
+    def _deco(self) -> TpLinkDeco:
+        """Return current deco object."""
+        return self._coordinator_decos.data.decos[self._deco_mac]
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return create_device_info(self._deco, self._coordinator_decos.data.master_deco)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._update_state()
+        self.async_write_ha_state()
+
+    def _update_state(self) -> None:
+        """Update sensor state."""
+        count = 0
+        for client in self.coordinator.data.values():
+            if client.deco_mac == self._deco_mac:
+                count += 1
+        self._attr_native_value = count
+
+
+class TplinkDecoDiagnosticSensor(CoordinatorEntity, SensorEntity):
+    """TP-Link Deco diagnostic sensor entity."""
+
+    entity_description: TplinkDecoDiagnosticSensorDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator_decos: TplinkDecoUpdateCoordinator,
+        deco_mac: str,
+        description: TplinkDecoDiagnosticSensorDescription,
+    ) -> None:
+        super().__init__(coordinator_decos)
+        self._deco_mac = deco_mac
+        self.entity_description = description
+        self._attr_unique_id = f"{deco_mac}_{description.key}"
+        self._attr_has_entity_name = True
+
+    @property
+    def _deco(self) -> TpLinkDeco:
+        """Return current deco object."""
+        return self.coordinator.data.decos[self._deco_mac]
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return create_device_info(self._deco, self.coordinator.data.master_deco)
+
+    @property
+    def native_value(self) -> str | None:
+        value = self.entity_description.value_fn(self._deco)
+        return value if value else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ homeassistant==2025.1.0
 isort==7.0.0
 pip>=21.0,<26.1
 pre-commit==4.5.1
-ruff==0.15.7
+ruff==0.15.8


### PR DESCRIPTION
## Summary

This PR restores compatibility with Home Assistant 2026.4.x and adds additional diagnostic entities for TP-Link Deco devices.

## Changes

### Compatibility
- fix integration loading issues on newer Home Assistant versions
- improve device registration by adding MAC address as a device connection
- make `inet_status` parsing more robust for different API return formats

### New entities

#### Sensors
- Connected clients per Deco
- Backhaul type
- IP address
- BSSID 2.4 GHz
- BSSID 5 GHz

#### Binary sensors
- Internet online (WAN status)
- Deco online (mesh/backhaul status)

## Why

The integration was no longer working on recent Home Assistant versions.

Additionally, Deco already exposes useful diagnostic data internally, but it was not available as entities. Exposing these improves:

- troubleshooting
- dashboards
- automation possibilities

## Testing

Tested locally on Home Assistant 2026.4.x with a TP-Link Deco setup.

Verified:
- integration loads without errors
- devices are discovered correctly
- all sensors and binary sensors update correctly
- no startup warnings or crashes