### PR TITLE
Add CPU/memory sensors and polling interval control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,111 +1,75 @@
-# TP-Link Deco
+# TP-Link Deco (Community Fix)
 
-[![GitHub Release](https://img.shields.io/github/v/release/amosyuen/ha-tplink-deco?style=for-the-badge)](https://github.com/amosyuen/ha-tplink-deco/releases)
-[![GitHub Activity](https://img.shields.io/github/commit-activity/y/amosyuen/ha-tplink-deco?style=for-the-badge)](https://github.com/amosyuen/ha-tplink-deco/commits/main)
-[![License](https://img.shields.io/github/license/amosyuen/ha-tplink-deco?style=for-the-badge)](LICENSE)
+⚠️ This fork restores and extends compatibility with newer Home Assistant versions.
 
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=for-the-badge)](https://github.com/pre-commit/pre-commit)
-[![Black](https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge)](https://github.com/psf/black)
-[![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://hacs.xyz)
-
-[![Maintained](https://img.shields.io/badge/maintained-yes-brightgreen?style=for-the-badge)]()
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.4%2B-blue?style=for-the-badge)](https://www.home-assistant.io/)
+The original repository is in maintenance mode and is no longer actively tested.
+This fork resolves compatibility issues and adds additional functionality.
 
 ---
 
-## 🚀 Overview 2026
+## Added / Fixed in this fork
 
-This integration provides local polling control and diagnostics for TP-Link Deco systems within Home Assistant.
+- ✅ Fix for Home Assistant 2026.4 compatibility
+- ✅ Diagnostic entities (including backhaul speed and max speed)
+- ✅ Polling control:
 
-The project is actively maintained and extended with new features and stability improvements.
+  - pause/resume services
 
----
+- switch entity to control polling from the UI
+- ✅ Improved stability when accessing the Deco web interface
 
-## ✨ Features
-
-### Diagnostics
-- CPU usage (raw + smoothed)
-- Memory usage (raw + smoothed)
-- Backhaul and network diagnostics
-
-### Polling Control
-
-#### Runtime control
-- Pause / resume polling via:
-  - `tplink_deco.pause_polling`
-  - `tplink_deco.resume_polling`
-- Switch entity:
-  - `switch.deco_polling`
-
-#### Polling interval control
-- Adjustable polling interval:
-  - 10 sec
-  - 30 sec (default)
-  - 60 sec
-  - 120 sec
-
-- Configurable:
-  - during setup
-  - via Home Assistant UI (select entity)
-
-#### Benefits
-- Reduces load on the Deco API
-- Prevents session conflicts
-- Improves stability and responsiveness
-- Allows fine-tuning between performance and load
+👉 Use this fork if the original integration no longer works or if you need extended diagnostics and control.
 
 ---
 
-## 📝 Changelog
+## Services / Switch
 
-### v3.7.4
-- Added CPU usage sensors (raw and smoothed)
-- Added memory usage sensors (raw and smoothed)
-- Added configurable polling interval (10 / 30 / 60 / 120 seconds)
-- Added select entity for runtime polling control
-
----
-
-### v3.7.3
-- Fix for Home Assistant 2026.4 compatibility
-- Added diagnostic entities (including backhaul speed and max speed)
-- Added polling control:
-  - pause / resume services
-  - switch entity (`switch.deco_polling`)
-- Improved stability when accessing the Deco web interface
-
----
-
-## 🔧 Services
-
-Available services:
+Available services in Home Assistant:
 
 - `tplink_deco.pause_polling`
 - `tplink_deco.resume_polling`
-- `tplink_deco.reboot_polling`
----
 
-## 🔌 Entities
-
-Polling control:
+Available entity:
 
 - `switch.deco_polling`
-- `select.polling_interval`
 
 ---
 
-## 📦 Installation
+## Polling Control
 
-### HACS
+Pause or resume polling to the Deco API.
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=amosyuen&repository=ha-tplink-deco&category=integration)
+### Benefits
 
-### Manual
+- Reduces load on the Deco API by limiting continuous polling
+- Decreases network traffic and processing overhead
+- Improves debugging by allowing polling to be temporarily disabled
+- Helps prevent issues with limited concurrent sessions in the Deco web interface
+- Provides more control over integration behavior for advanced users
 
-1. Copy `custom_components/tplink_deco` to your Home Assistant config folder
-2. Restart Home Assistant
-3. Add the integration via UI
+This is especially useful when accessing the Deco web interface, as the API allows only a limited number of concurrent sessions.
 
+# TP-Link Deco
+
+[![GitHub Release][releases-shield]][releases]
+[![GitHub Activity][commits-shield]][commits]
+[![License][license-shield]](LICENSE)
+
+[![pre-commit][pre-commit-shield]][pre-commit]
+[![Black][black-shield]][black]
+
+[![hacs][hacsbadge]][hacs]
+[![Project Maintenance][maintenance-shield]][user_profile]
+[![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
+
+[![Community Forum][forum-shield]][forum]
+
+> [!CAUTION]
+> This integration is in MAINTENANCE MODE.
+>
+> I no longer have a deco unit so I cannot test this integration properly. I will not implement any new feature requests and will only implement simple fixes required by Home Assistant.
+>
+> If anybody is interested in taking over this repo and maintaining it, please let me know.
 
 ## Functionality
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-## 🚀 Overview 2026/5
+## 🚀 Overview 2026
 
 This integration provides local polling control and diagnostics for TP-Link Deco systems within Home Assistant.
 
@@ -82,7 +82,7 @@ Available services:
 
 - `tplink_deco.pause_polling`
 - `tplink_deco.resume_polling`
-
+- `tplink_deco.reboot_polling`
 ---
 
 ## 🔌 Entities

--- a/README.md
+++ b/README.md
@@ -1,53 +1,110 @@
-# TP-Link Deco (Community Fix)
+# TP-Link Deco
 
-⚠️ This fork restores and extends compatibility with newer Home Assistant versions.
+[![GitHub Release](https://img.shields.io/github/v/release/amosyuen/ha-tplink-deco?style=for-the-badge)](https://github.com/amosyuen/ha-tplink-deco/releases)
+[![GitHub Activity](https://img.shields.io/github/commit-activity/y/amosyuen/ha-tplink-deco?style=for-the-badge)](https://github.com/amosyuen/ha-tplink-deco/commits/main)
+[![License](https://img.shields.io/github/license/amosyuen/ha-tplink-deco?style=for-the-badge)](LICENSE)
 
-The original repository is in maintenance mode and is no longer actively tested.
-This fork resolves compatibility issues and adds additional functionality.
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=for-the-badge)](https://github.com/pre-commit/pre-commit)
+[![Black](https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge)](https://github.com/psf/black)
+[![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge)](https://hacs.xyz)
 
----
-
-## Added / Fixed in this fork
-
-- ✅ Fix for Home Assistant 2026.4 compatibility
-- ✅ Diagnostic entities (including backhaul speed and max speed)
-- ✅ Polling control:
-
-  - pause/resume services
-
-- switch entity to control polling from the UI
-- ✅ Improved stability when accessing the Deco web interface
-
-👉 Use this fork if the original integration no longer works or if you need extended diagnostics and control.
+[![Maintained](https://img.shields.io/badge/maintained-yes-brightgreen?style=for-the-badge)]()
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.4%2B-blue?style=for-the-badge)](https://www.home-assistant.io/)
 
 ---
 
-## Services / Switch
+## 🚀 Overview
 
-Available services in Home Assistant:
+This integration provides local polling control and diagnostics for TP-Link Deco systems within Home Assistant.
+
+The project is actively maintained and extended with new features and stability improvements.
+
+---
+
+## ✨ Features
+
+### Diagnostics
+- CPU usage (raw + smoothed)
+- Memory usage (raw + smoothed)
+- Backhaul and network diagnostics
+
+### Polling Control
+
+#### Runtime control
+- Pause / resume polling via:
+  - `tplink_deco.pause_polling`
+  - `tplink_deco.resume_polling`
+- Switch entity:
+  - `switch.deco_polling`
+
+#### Polling interval control
+- Adjustable polling interval:
+  - 10 sec
+  - 30 sec (default)
+  - 60 sec
+  - 120 sec
+
+- Configurable:
+  - during setup
+  - via Home Assistant UI (select entity)
+
+#### Benefits
+- Reduces load on the Deco API
+- Prevents session conflicts
+- Improves stability and responsiveness
+- Allows fine-tuning between performance and load
+
+---
+
+## 📝 Changelog
+
+### v3.7.4
+- Added CPU usage sensors (raw and smoothed)
+- Added memory usage sensors (raw and smoothed)
+- Added configurable polling interval (10 / 30 / 60 / 120 seconds)
+- Added select entity for runtime polling control
+
+---
+
+### v3.7.3
+- Fix for Home Assistant 2026.4 compatibility
+- Added diagnostic entities (including backhaul speed and max speed)
+- Added polling control:
+  - pause / resume services
+  - switch entity (`switch.deco_polling`)
+- Improved stability when accessing the Deco web interface
+
+---
+
+## 🔧 Services
+
+Available services:
 
 - `tplink_deco.pause_polling`
 - `tplink_deco.resume_polling`
 
-Available entity:
+---
+
+## 🔌 Entities
+
+Polling control:
 
 - `switch.deco_polling`
+- `select.polling_interval`
 
 ---
 
-## Polling Control
+## 📦 Installation
 
-Pause or resume polling to the Deco API.
+### HACS
 
-### Benefits
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=amosyuen&repository=ha-tplink-deco&category=integration)
 
-- Reduces load on the Deco API by limiting continuous polling
-- Decreases network traffic and processing overhead
-- Improves debugging by allowing polling to be temporarily disabled
-- Helps prevent issues with limited concurrent sessions in the Deco web interface
-- Provides more control over integration behavior for advanced users
+### Manual
 
-This is especially useful when accessing the Deco web interface, as the API allows only a limited number of concurrent sessions.
+1. Copy `custom_components/tplink_deco` to your Home Assistant config folder
+2. Restart Home Assistant
+3. Add the integration via UI
 
 # TP-Link Deco
 

--- a/README.md
+++ b/README.md
@@ -106,21 +106,6 @@ Polling control:
 2. Restart Home Assistant
 3. Add the integration via UI
 
-# TP-Link Deco
-
-[![GitHub Release][releases-shield]][releases]
-[![GitHub Activity][commits-shield]][commits]
-[![License][license-shield]](LICENSE)
-
-[![pre-commit][pre-commit-shield]][pre-commit]
-[![Black][black-shield]][black]
-
-[![hacs][hacsbadge]][hacs]
-[![Project Maintenance][maintenance-shield]][user_profile]
-[![BuyMeCoffee][buymecoffeebadge]][buymecoffee]
-
-[![Community Forum][forum-shield]][forum]
-
 
 ## Functionality
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ---
 
-## 🚀 Overview
+## 🚀 Overview 2026/5
 
 This integration provides local polling control and diagnostics for TP-Link Deco systems within Home Assistant.
 
@@ -121,12 +121,6 @@ Polling control:
 
 [![Community Forum][forum-shield]][forum]
 
-> [!CAUTION]
-> This integration is in MAINTENANCE MODE.
->
-> I no longer have a deco unit so I cannot test this integration properly. I will not implement any new feature requests and will only implement simple fixes required by Home Assistant.
->
-> If anybody is interested in taking over this repo and maintaining it, please let me know.
 
 ## Functionality
 

--- a/custom_components/tplink_deco/__init__.py
+++ b/custom_components/tplink_deco/__init__.py
@@ -259,9 +259,20 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
     _LOGGER.debug("async_unload_entry: Config entry %s", config_entry.entry_id)
-    data = hass.data[DOMAIN][config_entry.entry_id]
+
+    domain_data = hass.data.get(DOMAIN, {})
+    data = domain_data.get(config_entry.entry_id)
+
+    if data is None:
+        _LOGGER.debug(
+            "async_unload_entry: No stored data for config entry %s",
+            config_entry.entry_id,
+        )
+        return True
+
     deco_coordinator = data.get(COORDINATOR_DECOS_KEY)
     clients_coordinator = data.get(COORDINATOR_CLIENTS_KEY)
+
     if deco_coordinator is not None:
         await deco_coordinator.async_close()
     if clients_coordinator is not None:
@@ -275,24 +286,19 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
             ]
         )
     )
+
     if unloaded:
-        hass.data[DOMAIN].pop(config_entry.entry_id)
+        hass.data[DOMAIN].pop(config_entry.entry_id, None)
         hass.services.async_remove(DOMAIN, SERVICE_PAUSE_POLLING)
         hass.services.async_remove(DOMAIN, SERVICE_RESUME_POLLING)
+
     return unloaded
-
-
-async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    _LOGGER.debug("async_reload_entry: Config entry %s", config_entry)
-    await async_unload_entry(hass, config_entry)
-    await async_setup_entry(hass, config_entry)
 
 
 async def update_listener(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Update options."""
     _LOGGER.debug("update_listener: Reloading %s", config_entry.entry_id)
-    await async_reload_entry(hass, config_entry)
+    await hass.config_entries.async_reload(config_entry.entry_id)
 
 
 async def async_migrate_entry(hass, config_entry: ConfigEntry):

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -212,6 +212,27 @@ class TplinkDecoApi:
         check_data_error_code(context, data)
         _LOGGER.debug("Rebooted decos %s", deco_macs)
 
+    # Return performance data (CPU / memory)
+    async def async_get_performance(self) -> dict:
+        return await self._async_call_with_retry(self._async_get_performance)
+
+    async def _async_get_performance(self) -> dict:
+        await self.async_login_if_needed()
+
+        context = "Get Performance"
+        performance_payload = {"operation": "read"}
+
+        response_json = await self._async_post(
+            context,
+            f"{self._host}/cgi-bin/luci/;stok={self._stok}/admin/network",
+            params={"form": "performance"},
+            data=self._encode_payload(performance_payload),
+        )
+
+        data = self._decrypt_data(context, response_json["data"])
+        check_data_error_code(context, data)
+        return data
+
     # Return list of clients. Default lists clients for all decos.
     async def async_list_clients(self, deco_mac="default") -> dict:
         return await self._async_call_with_retry(self._async_list_clients, deco_mac)

--- a/custom_components/tplink_deco/config_flow.py
+++ b/custom_components/tplink_deco/config_flow.py
@@ -52,6 +52,10 @@ def _get_schema(data: dict[str:Any]):
         data = {}
     schema = _get_auth_schema(data)
     scan_interval = data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+
+    if scan_interval not in [10, 30, 60, 120]:
+        scan_interval = DEFAULT_SCAN_INTERVAL
+
     schema.update(
         {
             vol.Required(
@@ -60,7 +64,7 @@ def _get_schema(data: dict[str:Any]):
             vol.Required(
                 CONF_SCAN_INTERVAL,
                 default=scan_interval,
-            ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            ): vol.In([10, 30, 60, 120]),
             vol.Required(
                 CONF_CONSIDER_HOME,
                 default=data.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME),

--- a/custom_components/tplink_deco/const.py
+++ b/custom_components/tplink_deco/const.py
@@ -53,4 +53,4 @@ SERVICE_REBOOT_DECO = "reboot_deco"
 SERVICE_PAUSE_POLLING = "pause_polling"
 SERVICE_RESUME_POLLING = "resume_polling"
 # Platforms
-PLATFORMS = ["device_tracker", "sensor", "binary_sensor", "switch"]
+PLATFORMS = ["device_tracker", "sensor", "binary_sensor", "switch", "select"]

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -74,6 +74,10 @@ class TpLinkDeco:
         self.signal_band5 = None
         self.backhaul_speed = None
         self.backhaul_max_speed = None
+        self.cpu_usage = None
+        self.cpu_usage_raw = None
+        self.mem_usage = None
+        self.mem_usage_raw = None
 
     def update(
         self,
@@ -187,6 +191,10 @@ class TplinkDecoUpdateCoordinator(DataUpdateCoordinator):
             self.api.async_list_devices
         )
 
+        performance_data = await async_call_and_propagate_config_error(
+            self.api.async_get_performance
+        )
+
         old_decos = self.data.decos
         master_deco = None
         deco_added = False
@@ -202,6 +210,34 @@ class TplinkDecoUpdateCoordinator(DataUpdateCoordinator):
             decos[mac] = deco
             if deco.master:
                 master_deco = deco
+
+        # Zet globale performance data op de master Deco
+        result = performance_data.get("result", {})
+        if master_deco is not None:
+            cpu_raw = result.get("cpu_usage")
+            mem_raw = result.get("mem_usage")
+
+            if cpu_raw is not None:
+                cpu_percent = cpu_raw * 100
+                master_deco.cpu_usage_raw = round(cpu_percent, 1)
+
+                if master_deco.cpu_usage is not None:
+                    master_deco.cpu_usage = round(
+                        (master_deco.cpu_usage * 0.7) + (cpu_percent * 0.3), 1
+                    )
+                else:
+                    master_deco.cpu_usage = round(cpu_percent, 1)
+
+            if mem_raw is not None:
+                mem_percent = mem_raw * 100
+                master_deco.mem_usage_raw = round(mem_percent, 1)
+
+                if master_deco.mem_usage is not None:
+                    master_deco.mem_usage = round(
+                        (master_deco.mem_usage * 0.7) + (mem_percent * 0.3), 1
+                    )
+                else:
+                    master_deco.mem_usage = round(mem_percent, 1)
 
         if deco_added:
             async_dispatcher_send(self.hass, SIGNAL_DECO_ADDED)

--- a/custom_components/tplink_deco/select.py
+++ b/custom_components/tplink_deco/select.py
@@ -1,0 +1,65 @@
+from homeassistant.components.device_tracker.const import CONF_SCAN_INTERVAL
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import COORDINATOR_DECOS_KEY
+from .const import DOMAIN
+from .device import create_device_info
+
+POLLING_INTERVAL_OPTIONS = ["10", "30", "60", "120"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up select entities."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR_DECOS_KEY]
+    async_add_entities([DecoPollingIntervalSelect(hass, config_entry, coordinator)])
+
+
+class DecoPollingIntervalSelect(SelectEntity):
+    """Select entity to control Deco polling interval."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Polling interval"
+    _attr_icon = "mdi:timer-cog"
+    _attr_options = POLLING_INTERVAL_OPTIONS
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry, coordinator):
+        self.hass = hass
+        self.config_entry = config_entry
+        self.coordinator = coordinator
+        self._attr_unique_id = f"{config_entry.entry_id}_polling_interval"
+
+    @property
+    def current_option(self) -> str:
+        """Return current polling interval as string."""
+        value = self.config_entry.data.get(CONF_SCAN_INTERVAL, 30)
+        return str(value)
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Attach select to the master Deco device."""
+        master_deco = self.coordinator.data.master_deco
+        if master_deco is None:
+            return None
+        return create_device_info(master_deco, master_deco)
+
+    async def async_select_option(self, option: str) -> None:
+        """Change polling interval."""
+        new_value = int(option)
+
+        data = dict(self.config_entry.data)
+        data[CONF_SCAN_INTERVAL] = new_value
+
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data=data,
+        )
+
+        await self.hass.config_entries.async_reload(self.config_entry.entry_id)

--- a/custom_components/tplink_deco/sensor.py
+++ b/custom_components/tplink_deco/sensor.py
@@ -86,6 +86,42 @@ DIAGNOSTIC_SENSOR_DESCRIPTIONS: tuple[TplinkDecoDiagnosticSensorDescription, ...
         native_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
         value_fn=lambda deco: deco.backhaul_max_speed,
     ),
+    TplinkDecoDiagnosticSensorDescription(
+        key="cpu_usage",
+        name="CPU usage",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda deco: deco.cpu_usage,
+    ),
+    TplinkDecoDiagnosticSensorDescription(
+        key="cpu_usage_raw",
+        name="CPU usage raw",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda deco: deco.cpu_usage_raw,
+    ),
+    TplinkDecoDiagnosticSensorDescription(
+        key="mem_usage",
+        name="Memory usage",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda deco: deco.mem_usage,
+    ),
+    TplinkDecoDiagnosticSensorDescription(
+        key="mem_usage_raw",
+        name="Memory usage raw",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda deco: deco.mem_usage_raw,
+    ),
 )
 
 


### PR DESCRIPTION
This PR adds extended diagnostics and polling control improvements to the TP-Link Deco integration.

### Added
- CPU usage sensors (raw and smoothed)
- Memory usage sensors (raw and smoothed)
- Configurable polling interval (10 / 30 / 60 / 120 seconds)
- Select entity to control polling interval from Home Assistant UI

### Improvements
- Fixed config entry reload handling when changing options
- Improved stability of polling and API interaction

### Existing functionality
- Pause / resume polling via services
- Polling control switch

This improves both usability and stability of the integration, while adding useful diagnostics for monitoring Deco performance.