### PR TITLE
Fix Deco offline state handling and hassfest translation validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ Two types of sensors are available:
 - **Smoothed** → averaged values over time (stable, ideal for dashboards)
 
 **Use raw for:**
+
 - debugging
 - real-time monitoring
 
 **Use smoothed for:**
+
 - dashboards
 - automations
 - trend analysis
@@ -50,6 +52,7 @@ Two types of sensors are available:
 #### Runtime control
 
 - Pause / resume polling:
+
   - `tplink_deco.pause_polling`
   - `tplink_deco.resume_polling`
 
@@ -68,6 +71,7 @@ Adjustable polling interval:
 - 120 sec
 
 Configurable:
+
 - during setup
 - via Home Assistant UI (select entity)
 

--- a/custom_components/tplink_deco/binary_sensor.py
+++ b/custom_components/tplink_deco/binary_sensor.py
@@ -73,14 +73,18 @@ class TplinkDecoInternetOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity
         self._attr_unique_id = f"{deco_mac}_internet_online"
 
     @property
-    def _deco(self) -> TpLinkDeco:
+    def _deco(self) -> TpLinkDeco | None:
         """Return current deco object."""
-        return self.coordinator.data.decos[self._deco_mac]
+        return self.coordinator.data.decos.get(self._deco_mac)
 
     @property
     def is_on(self) -> bool:
         """Return true if internet is online."""
-        value = self._deco.internet_online
+        deco = self._deco
+        if deco is None:
+            return False
+
+        value = deco.internet_online
 
         if isinstance(value, str):
             return value.lower() in ("online", "true", "1", "yes")
@@ -89,13 +93,17 @@ class TplinkDecoInternetOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity
 
     @property
     def available(self) -> bool:
-        return self._deco is not None and self._deco.internet_online is not None
+        return True
 
     @property
     def device_info(self):
         """Return device info."""
+        deco = self._deco
+        if deco is None:
+            return None
+
         return create_device_info(
-            self._deco,
+            deco,
             self.coordinator.data.master_deco,
         )
 
@@ -114,19 +122,26 @@ class TplinkDecoOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def _deco(self):
-        return self.coordinator.data.decos[self._deco_mac]
+        return self.coordinator.data.decos.get(self._deco_mac)
 
     @property
     def is_on(self):
-        return bool(self._deco.online)
+        deco = self._deco
+        if deco is None:
+            return False
+        return bool(deco.online)
 
     @property
     def available(self):
-        return self._deco is not None
+        return True
 
     @property
     def device_info(self):
+        deco = self._deco
+        if deco is None:
+            return None
+
         return create_device_info(
-            self._deco,
+            deco,
             self.coordinator.data.master_deco,
         )

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -211,6 +211,16 @@ class TplinkDecoUpdateCoordinator(DataUpdateCoordinator):
             if deco.master:
                 master_deco = deco
 
+        for mac, old_deco in old_decos.items():
+            if mac not in decos:
+                _LOGGER.debug(
+                    "_async_update_data: Deco mac=%s not returned by API, marking offline",
+                    mac,
+                )
+                old_deco.online = False
+                old_deco.internet_online = False
+                decos[mac] = old_deco
+
         # Zet globale performance data op de master Deco
         result = performance_data.get("result", {})
         if master_deco is not None:

--- a/custom_components/tplink_deco/strings.json
+++ b/custom_components/tplink_deco/strings.json
@@ -2,13 +2,13 @@
   "config": {
     "step": {
       "user": {
-        "description": "Use the credentials for the admin web portal. See documentation for more information",
+        "description": "Use the credentials for the admin web portal. See the documentation for setup details.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "interval_seconds": "Seconds between updates",
-          "consider_home": "Seconds to wait till marking a device tracker as not home after not being seen.",
+          "scan_interval": "Seconds between updates",
+          "consider_home": "Seconds to wait before marking a device tracker as not home after it is no longer seen.",
           "timeout_seconds": "Timeout seconds",
           "timeout_error_retries": "Timeout error retry count",
           "verify_ssl": "Verify SSL certificate is valid",
@@ -19,7 +19,7 @@
         }
       },
       "reauth_confirm": {
-        "description": "Problem with login credentials. Maybe caused by logging in on a separate device. See documentation for more information",
+        "description": "Problem with login credentials. This may be caused by logging in on a separate device. See the documentation for login requirements.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
@@ -31,18 +31,21 @@
       "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {
     "step": {
       "init": {
-        "description": "Use the credentials for the admin web portal. See documentation for more information",
+        "description": "Use the credentials for the admin web portal. See the documentation for setup details.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "interval_seconds": "Seconds between updates",
-          "consider_home": "Seconds to wait till marking a device tracker as not home after not being seen.",
+          "scan_interval": "Seconds between updates",
+          "consider_home": "Seconds to wait before marking a device tracker as not home after it is no longer seen.",
           "timeout_seconds": "Timeout seconds",
           "timeout_error_retries": "Timeout error retry count",
           "verify_ssl": "Verify SSL certificate is valid",

--- a/custom_components/tplink_deco/translations/en.json
+++ b/custom_components/tplink_deco/translations/en.json
@@ -2,13 +2,13 @@
   "config": {
     "step": {
       "user": {
-        "description": "Use the credentials for the admin web portal. See documentation for more information",
+        "description": "Use the credentials for the admin web portal. See the documentation for setup details.",
         "data": {
           "host": "Host",
           "username": "Username",
           "password": "Password",
-          "interval_seconds": "Seconds between updates",
-          "consider_home": "Seconds to wait till marking a device tracker as not home after not being seen.",
+          "scan_interval": "Seconds between updates",
+          "consider_home": "Seconds to wait before marking a device tracker as not home after it is no longer seen.",
           "timeout_seconds": "Timeout seconds",
           "timeout_error_retries": "Timeout error retry count",
           "verify_ssl": "Verify SSL certificate is valid",
@@ -19,7 +19,7 @@
         }
       },
       "reauth_confirm": {
-        "description": "Problem with login credentials. Maybe caused by logging in on a separate device. See documentation for more information.",
+        "description": "Problem with login credentials. This may be caused by logging in on a separate device. See the documentation for login requirements.",
         "data": {
           "username": "Username",
           "password": "Password"
@@ -27,7 +27,7 @@
       }
     },
     "abort": {
-      "reauth_successful": "Reauth successful"
+      "reauth_successful": "Reauthentication successful"
     },
     "error": {
       "invalid_auth": "Invalid authentication",
@@ -39,13 +39,13 @@
   "options": {
     "step": {
       "init": {
-        "description": "Use the credentials for the admin web portal. See documentation for more information",
+        "description": "Use the credentials for the admin web portal. See the documentation for setup details.",
         "data": {
           "host": "Host",
           "username": "Username",
           "password": "Password",
-          "interval_seconds": "Seconds between updates",
-          "consider_home": "Seconds to wait till marking a device tracker as not home after not being seen.",
+          "scan_interval": "Seconds between updates",
+          "consider_home": "Seconds to wait before marking a device tracker as not home after it is no longer seen.",
           "timeout_seconds": "Timeout seconds",
           "timeout_error_retries": "Timeout error retry count",
           "verify_ssl": "Verify SSL certificate is valid",
@@ -55,6 +55,9 @@
           "deco_postfix": "Deco name postfix"
         }
       }
+    },
+    "abort": {
+      "reauth_successful": "Reauthentication successful"
     },
     "error": {
       "invalid_auth": "Invalid authentication",


### PR DESCRIPTION
## Summary

This PR fixes incorrect online state handling for Deco devices and resolves hassfest translation validation errors.

---

## Fixes

### 1. Deco offline handling

Previously, when a Deco device went offline, it was removed from the coordinator data.  
This caused binary sensors (`Deco online` and `Internet online`) to retain stale values.

Changes:
- Keep previously known Deco devices in coordinator data
- Explicitly set:
  - `online = False`
  - `internet_online = False`
- Ensure sensors correctly switch to OFF when a Deco is no longer reachable

---

### 2. API failure handling

Improved behavior when the Deco API or router is temporarily unavailable:

- Binary sensors now fall back to `off`
- Prevents stale "online" states
- Avoids unwanted `unavailable` states for core connectivity sensors

---

### 3. Translation / Hassfest fixes

Resolved hassfest validation errors:

- Removed URLs from translation strings
- Fixed structure of `strings.json` and `translations/en.json`
- Ensured correct `data` blocks and keys (e.g. `scan_interval`)

---

## Result

- Correct online/offline behavior for Deco devices
- Stable sensor states during API interruptions
- Hassfest validation passes

---

## Testing

Tested the following scenarios:

- Turning a slave Deco on/off
- Temporary API/router unavailability
- Config flow and options flow still working correctly

All scenarios behave as expected.

Closes issue number #505 