### PR TITLE
Fix client naming by adding ui_device_name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ Two types of sensors are available:
 - **Smoothed** → averaged values over time (stable, ideal for dashboards)
 
 **Use raw for:**
+
 - debugging
 - real-time monitoring
 
 **Use smoothed for:**
+
 - dashboards
 - automations
 - trend analysis
@@ -50,6 +52,7 @@ Two types of sensors are available:
 #### Runtime control
 
 - Pause / resume polling:
+
   - `tplink_deco.pause_polling`
   - `tplink_deco.resume_polling`
 
@@ -68,6 +71,7 @@ Adjustable polling interval:
 - 120 sec
 
 Configurable:
+
 - during setup
 - via Home Assistant UI (select entity)
 

--- a/custom_components/tplink_deco/const.py
+++ b/custom_components/tplink_deco/const.py
@@ -34,6 +34,7 @@ ATTR_MASTER = "master"
 ATTR_SIGNAL_BAND2_4 = "signal_band2_4"
 ATTR_SIGNAL_BAND5 = "signal_band5"
 ATTR_UP_KILOBYTES_PER_S = "up_kilobytes_per_s"
+ATTR_UI_DEVICE_NAME = "ui_device_name"
 
 # Config
 CONF_CLIENT_PREFIX = "client_prefix"

--- a/custom_components/tplink_deco/device_tracker.py
+++ b/custom_components/tplink_deco/device_tracker.py
@@ -29,6 +29,7 @@ from .const import ATTR_INTERNET_ONLINE
 from .const import ATTR_MASTER
 from .const import ATTR_SIGNAL_BAND2_4
 from .const import ATTR_SIGNAL_BAND5
+from .const import ATTR_UI_DEVICE_NAME
 from .const import ATTR_UP_KILOBYTES_PER_S
 from .const import CONF_CLIENT_POSTFIX
 from .const import CONF_CLIENT_PREFIX
@@ -404,6 +405,7 @@ class TplinkDecoClientDeviceTracker(CoordinatorEntity, RestoreEntity, ScannerEnt
             ATTR_UP_KILOBYTES_PER_S: self._client.up_kilobytes_per_s,
             ATTR_DECO_DEVICE: None if deco is None else deco.name,
             ATTR_DECO_MAC: self._attr_deco_mac,
+            ATTR_UI_DEVICE_NAME: self._attr_name,
         }
 
     @property


### PR DESCRIPTION
## Summary

Home Assistant automatically builds the `friendly_name` of client entities using the associated Deco device name (e.g. `Study Room Deco ApSystemsEcuR`).  
This behavior cannot be safely overridden without breaking device grouping or HA naming conventions.

This PR introduces a new attribute to expose the original client name from the Deco API.

---

## Changes

- Added new attribute: `ui_device_name`
- This attribute contains the raw client name without HA-generated prefixes
- Applied to all client device tracker entities

---

## Example

Current HA behavior:
- `friendly_name`: `Study Room Deco ApSystemsEcuR`

New attribute:
- `ui_device_name`: `ApSystemsEcuR`

---

## Rationale

- Keeps Home Assistant naming behavior intact
- Avoids breaking device grouping (clients remain linked to Deco devices)
- Provides a clean, stable name for UI usage (cards, templates, sorting)

---

## Usage

Users can use the attribute in templates:

```jinja
{{ state_attr(entity_id, 'ui_device_name') }}