### PR TITLE
fix: prevent session churn and add request serialization

### DIFF
--- a/custom_components/tplink_deco/__init__.py
+++ b/custom_components/tplink_deco/__init__.py
@@ -273,10 +273,15 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     deco_coordinator = data.get(COORDINATOR_DECOS_KEY)
     clients_coordinator = data.get(COORDINATOR_CLIENTS_KEY)
 
+    # Cancel any in-flight refresh before logout to avoid lock contention
     if deco_coordinator is not None:
-        await deco_coordinator.async_close()
+        await deco_coordinator.async_shutdown()
     if clients_coordinator is not None:
-        await clients_coordinator.async_close()
+        await clients_coordinator.async_shutdown()
+
+    # Logout from the Deco to free the admin session
+    if deco_coordinator is not None:
+        await deco_coordinator.api.async_logout()
 
     unloaded = all(
         await asyncio.gather(

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -151,6 +151,10 @@ class TplinkDecoApi:
         self._stok = None
         self._cookie = None
 
+        # Lock to serialize all requests to the Deco management API.
+        # The Deco firmware cannot handle concurrent admin requests reliably.
+        self._request_lock = asyncio.Lock()
+
         if verify_ssl:
             self._ssl_context = None
         else:
@@ -194,6 +198,12 @@ class TplinkDecoApi:
 
     # Reboot decos.
     async def async_reboot_decos(self, deco_macs) -> dict:
+        """Reboot specified Deco nodes (serialized through the request lock)."""
+        return await self._async_call_with_retry(
+            self._async_reboot_decos_inner, deco_macs
+        )
+
+    async def _async_reboot_decos_inner(self, deco_macs) -> dict:
         await self.async_login_if_needed()
 
         context = f"Reboot Decos {deco_macs}"
@@ -484,10 +494,11 @@ class TplinkDecoApi:
                 raise ForbiddenException(message) from err
             raise err
         except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError) as err:
-            # Clear auth in case deco rebooted and auth is invalid
-            self.clear_auth()
-            _LOGGER.error(
-                "%s connection error: %s",
+            # Do NOT clear auth here — a transient network error does not mean
+            # the session is invalid. Clearing auth causes a re-login which creates
+            # a new session on the Deco, leading to session table exhaustion.
+            _LOGGER.warning(
+                "%s connection error (keeping session): %s",
                 context,
                 err,
             )
@@ -509,8 +520,8 @@ class TplinkDecoApi:
 
     def _encode_sign(self, data_len: int):
         if self._seq is None:
-            self.clear_auth()
-            message = "_seq is None"
+            # Session not initialized — need to login first
+            message = "_seq is None, login required"
             raise EmptyDataException(message)
         seq_with_data_len = self._seq + data_len
         auth_hash = (
@@ -537,9 +548,36 @@ class TplinkDecoApi:
         self._stok = None
         self._cookie = None
 
+    async def async_logout(self):
+        """Logout from the Deco to release the admin session."""
+        async with self._request_lock:
+            await self._async_logout_inner()
+
+    async def _async_logout_inner(self):
+        """Inner logout logic, must be called under _request_lock."""
+        if self._stok is None or self._cookie is None:
+            self.clear_auth()
+            return
+        try:
+            _LOGGER.debug("Logging out from Deco")
+            logout_payload = {"operation": "logout"}
+            await self._async_post(
+                "Logout",
+                f"{self._host}/cgi-bin/luci/;stok={self._stok}/admin/system",
+                params={"form": "logout"},
+                data=json.dumps(logout_payload),
+            )
+        except Exception as err:
+            _LOGGER.debug("Logout failed (best effort): %s", err)
+        finally:
+            self.clear_auth()
+
     def _decrypt_data(self, context: str, data: str):
         if data == "":
-            self.clear_auth()
+            # Do NOT clear auth here — an empty response typically means the Deco
+            # is temporarily overloaded, not that the session is invalid.
+            # Clearing auth would trigger a re-login, creating a new session and
+            # potentially exhausting the Deco's limited session table.
             message = f"{context} data is empty"
             raise EmptyDataException(message)
 
@@ -563,6 +601,11 @@ class TplinkDecoApi:
             raise err
 
     async def _async_call_with_retry(self, func, *args):
+        """Call API function with retry logic and request serialization."""
+        async with self._request_lock:
+            return await self._async_call_with_retry_inner(func, *args)
+
+    async def _async_call_with_retry_inner(self, func, *args):
         relogin_retried = False
         timeout_retries = 0
         while True:
@@ -573,6 +616,12 @@ class TplinkDecoApi:
                     # Reached max relogin retries
                     raise err
                 relogin_retried = True
+                # Now clear auth and re-login for the retry attempt.
+                # We don't clear auth on the first occurrence (in _decrypt_data
+                # or connection error handlers) to avoid churning sessions on
+                # transient errors. But if we reach here, it may be a real
+                # session expiration, so we force a re-login for the 2nd try.
+                self.clear_auth()
                 _LOGGER.debug(
                     "Re-login and retry potential expired auth error: %s",
                     err,

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -1,6 +1,5 @@
 """TP-Link Deco Coordinator"""
 
-import asyncio
 from collections.abc import Callable
 from datetime import datetime
 from datetime import timedelta
@@ -15,6 +14,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .api import TplinkDecoApi
@@ -191,9 +191,15 @@ class TplinkDecoUpdateCoordinator(DataUpdateCoordinator):
             self.api.async_list_devices
         )
 
-        performance_data = await async_call_and_propagate_config_error(
-            self.api.async_get_performance
-        )
+        try:
+            performance_data = await async_call_and_propagate_config_error(
+                self.api.async_get_performance
+            )
+        except ConfigEntryAuthFailed:
+            raise
+        except Exception as err:
+            _LOGGER.debug("_async_update_data: Performance data unavailable: %s", err)
+            performance_data = None
 
         old_decos = self.data.decos
         master_deco = None
@@ -222,7 +228,7 @@ class TplinkDecoUpdateCoordinator(DataUpdateCoordinator):
                 decos[mac] = old_deco
 
         # Zet globale performance data op de master Deco
-        result = performance_data.get("result", {})
+        result = performance_data.get("result", {}) if performance_data else {}
         if master_deco is not None:
             cpu_raw = result.get("cpu_usage")
             mem_raw = result.get("mem_usage")
@@ -313,37 +319,51 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         # List clients for all decos if _deco_update_coordinator is not provided
         deco_macs = self._deco_update_coordinator.data.decos.keys()
         utc_point_in_time = dt_util.utcnow()
-        # Send list client requests in parallel for each deco
-
-        deco_client_responses = await asyncio.gather(
-            *[
-                async_call_and_propagate_config_error(
+        # Send list client requests sequentially (serialization is now
+        # handled by the API request lock, no need for artificial delays)
+        failed_deco_macs = set()
+        successful_count = 0
+        for deco_mac in deco_macs:
+            try:
+                node_clients = await async_call_and_propagate_config_error(
                     self.api.async_list_clients, deco_mac
                 )
-                for deco_mac in deco_macs
-            ]
-        )
-
-        if len(deco_client_responses) > 0:
-            # deco_macs is not subscriptable, must be iterated
-            for deco_mac, deco_clients in zip(deco_macs, deco_client_responses):
-                for deco_client in deco_clients:
+                successful_count += 1
+                for deco_client in node_clients:
                     client_mac = deco_client["mac"]
                     client = old_clients.get(client_mac)
                     if client is None:
                         client_added = True
                         client = TpLinkDecoClient(client_mac)
                         _LOGGER.debug(
-                            "_async_update_data: Found new client mac=%s", client.mac
+                            "_async_update_data: Found new client mac=%s",
+                            client.mac,
                         )
                     client.update(deco_client, deco_mac, utc_point_in_time)
                     clients[client_mac] = client
+            except ConfigEntryAuthFailed:
+                raise
+            except Exception as err:
+                _LOGGER.warning(
+                    "_async_update_data: Failed to get clients for deco %s: %s",
+                    deco_mac,
+                    err,
+                )
+                failed_deco_macs.add(deco_mac)
+
+        if successful_count == 0 and len(failed_deco_macs) > 0:
+            raise UpdateFailed(
+                f"All {len(failed_deco_macs)} deco nodes failed to respond"
+            )
 
         # Copy over clients no longer online
         for client in old_clients.values():
             mac = client.mac
             if mac not in clients:
                 clients[mac] = client
+                if client.deco_mac in failed_deco_macs:
+                    # Node was unreachable; preserve client state as-is
+                    continue
                 if client.last_activity is None:
                     client.online = False
                 else:

--- a/custom_components/tplink_deco/select.py
+++ b/custom_components/tplink_deco/select.py
@@ -9,7 +9,7 @@ from .const import COORDINATOR_DECOS_KEY
 from .const import DOMAIN
 from .device import create_device_info
 
-POLLING_INTERVAL_OPTIONS = ["10", "30", "60", "120"]
+POLLING_INTERVAL_OPTIONS = ["10", "30", "60", "120", "180", "240", "300"]
 
 
 async def async_setup_entry(

--- a/custom_components/tplink_deco/sensor.py
+++ b/custom_components/tplink_deco/sensor.py
@@ -133,6 +133,13 @@ async def async_setup_entry(
     coordinator_decos = data[COORDINATOR_DECOS_KEY]
     coordinator_clients = data[COORDINATOR_CLIENTS_KEY]
 
+    master = coordinator_decos.data.master_deco
+    if master is None:
+        _LOGGER.warning(
+            "Master Deco not found; skipping sensor setup until next refresh"
+        )
+        return
+
     def add_sensors_for_deco(
         deco: TpLinkDeco | None,
     ):


### PR DESCRIPTION
## Problem

The TP-Link Deco integration creates excessive admin sessions on the router due to aggressive auth clearing on transient errors, and has presence flickering issues when individual mesh nodes are temporarily unreachable.

## Root Cause

1. **Session churn**: `clear_auth()` called on every transient error (empty response, timeout, network blip) → triggers re-login → new session → exhausts the Deco's limited session table (4-8 slots)
2. **No request serialization**: concurrent API calls collide on the single-session Deco firmware
3. **Presence flickering**: one failed node marks ALL clients as offline

## Fix

### Session management
- Stop clearing auth on transient errors (empty response, network timeouts)
- Only force re-login after 2nd consecutive Forbidden/EmptyData failure
- `asyncio.Lock` serializes all API requests (replaces sleep-based sequencing)
- `async_logout()` acquires `_request_lock` to prevent race with in-flight polls
- `async_shutdown()` cancels coordinators before logout at unload

### Presence tracking
- Track `failed_deco_macs` to preserve client state when individual nodes fail
- Raise `UpdateFailed` only when ALL nodes are unreachable
- Clients keep previous online/offline state during partial failures

### Performance endpoint
- `async_get_performance` wrapped in try/except (non-critical endpoint)
- Failure does not kill the deco coordinator update cycle

### Other
- Sensor crash guard when `master_deco is None`
- Scan interval select: added 180/240/300s options
- `async_reboot_decos` routed through `_async_call_with_retry` (serialized)

## Testing
Tested on TP-Link Deco M4 mesh (4 nodes), scan intervals from 30s to 300s. Stable over 3+ hours with zero session churn, no presence flickering, no crashes.