### PR TITLE
fix: address 8 preexisting bugs found during code audit

### DIFF
--- a/custom_components/tplink_deco/__init__.py
+++ b/custom_components/tplink_deco/__init__.py
@@ -63,12 +63,12 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 async def async_create_and_refresh_coordinators(
     hass: HomeAssistant,
-    config_data: dict[str:Any],
+    config_data: dict[str, Any],
     config_entry: ConfigEntry = None,
     consider_home_seconds=1,
     update_interval: timedelta = None,
     deco_data: TpLinkDecoData = None,
-    client_data: dict[str:TpLinkDecoClient] = None,
+    client_data: dict[str, TpLinkDecoClient] = None,
 ):
     host = config_data.get(CONF_HOST)
     username = config_data.get(CONF_USERNAME)
@@ -104,7 +104,7 @@ async def async_create_and_refresh_coordinators(
         client_data,
     )
     if config_entry is None:
-        await deco_coordinator._async_update_data()
+        await clients_coordinator._async_update_data()
     else:
         await clients_coordinator.async_config_entry_first_refresh()
 
@@ -197,39 +197,47 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     data = await async_create_config_data(hass, config_entry)
     hass.data[DOMAIN][config_entry.entry_id] = data
-    deco_coordinator = data[COORDINATOR_DECOS_KEY]
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     async def async_reboot_deco(service: ServiceCall) -> None:
         dr = device_registry.async_get(hass=hass)
-        device_ids = cast([str], service.data.get(ATTR_DEVICE_ID))
+        device_ids = cast(list[str], service.data.get(ATTR_DEVICE_ID))
         macs = []
+        target_coordinator = None
         for device_id in device_ids:
             device = dr.async_get(device_id)
             if device is None:
                 raise Exception(f"Device ID {device_id} is not a TP-Link Deco device")
             ids = device.identifiers
-            id = next(iter(ids)) if len(ids) == 1 else None
-            if id[0] != DOMAIN:
+            id = next((i for i in ids if i[0] == DOMAIN), None)
+            if id is None:
                 raise Exception(
                     f"Device ID {device_id} does not have {DOMAIN} MAC identifier"
                 )
             macs.append(id[1])
-        await deco_coordinator.api.async_reboot_decos(macs)
+            # Resolve coordinator from the config entry that owns this device
+            if target_coordinator is None:
+                for entry_id, entry_data in hass.data.get(DOMAIN, {}).items():
+                    coord = entry_data.get(COORDINATOR_DECOS_KEY)
+                    if coord and id[1] in coord.data.decos:
+                        target_coordinator = coord
+                        break
+        if target_coordinator is None:
+            raise Exception("Could not find coordinator for the target device(s)")
+        await target_coordinator.api.async_reboot_decos(macs)
 
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_REBOOT_DECO,
-        async_reboot_deco,
-        schema=vol.Schema(
-            {
-                vol.Required(ATTR_DEVICE_ID): vol.All(cv.ensure_list(str), [str]),
-            }
-        ),
-    )
+    if not hass.services.has_service(DOMAIN, SERVICE_REBOOT_DECO):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_REBOOT_DECO,
+            async_reboot_deco,
+            schema=vol.Schema(
+                {
+                    vol.Required(ATTR_DEVICE_ID): vol.All(cv.ensure_list(str), [str]),
+                }
+            ),
+        )
 
     async def handle_pause_polling(service: ServiceCall) -> None:
         """Handle pause polling service."""

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -482,6 +482,14 @@ class TplinkDecoApi:
                 self.clear_auth()
                 message = f"{context} Forbidden error: {err}"
                 raise ForbiddenException(message) from err
+            if err.status >= 500:
+                # Server error (502 Bad Gateway, etc.) — clear auth and retry
+                self.clear_auth()
+                _LOGGER.warning(
+                    "%s server error %s, clearing auth for retry",
+                    context,
+                    err.status,
+                )
             raise err
         except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError) as err:
             # Clear auth in case deco rebooted and auth is invalid

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -415,7 +415,7 @@ class TplinkDecoApi:
         self,
         context: str,
         url: str,
-        params: dict[str:Any],
+        params: dict[str, Any],
         data: Any,
     ) -> dict:
         headers = {CONTENT_TYPE: "application/json"}
@@ -443,7 +443,7 @@ class TplinkDecoApi:
 
                 # Verbeterde extractie: loop door alle Set-Cookie headers
                 for cookie_header in response.headers.getall(SET_COOKIE, []):
-                    match = re.search(r"(sysauth=[a-f0-9]+)", cookie_header)
+                    match = re.search(r"(sysauth=[a-zA-Z0-9_.-]+)", cookie_header)
                     if match:
                         self._cookie = match.group(1)
                         _LOGGER.debug("Found new cookie: %s", self._cookie)

--- a/custom_components/tplink_deco/config_flow.py
+++ b/custom_components/tplink_deco/config_flow.py
@@ -38,7 +38,7 @@ from .exceptions import TimeoutException
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-def _get_auth_schema(data: dict[str:Any]):
+def _get_auth_schema(data: dict[str, Any]):
     if data is None:
         data = {}
     return {
@@ -47,7 +47,7 @@ def _get_auth_schema(data: dict[str:Any]):
     }
 
 
-def _get_schema(data: dict[str:Any]):
+def _get_schema(data: dict[str, Any]):
     if data is None:
         data = {}
     schema = _get_auth_schema(data)
@@ -107,7 +107,7 @@ def _get_schema(data: dict[str:Any]):
 
 
 # We need to make sure the optional keys are set so that they get updated in update_listener async_update_entry() call
-def _ensure_user_input_optionals(data: dict[str:Any]) -> None:
+def _ensure_user_input_optionals(data: dict[str, Any]) -> None:
     for key in [
         CONF_CLIENT_PREFIX,
         CONF_CLIENT_POSTFIX,
@@ -118,7 +118,7 @@ def _ensure_user_input_optionals(data: dict[str:Any]) -> None:
             data[key] = ""
 
 
-async def _async_test_credentials(hass: HomeAssistant, data: dict[str:Any]):
+async def _async_test_credentials(hass: HomeAssistant, data: dict[str, Any]):
     """Return true if credentials is valid."""
     try:
         coordinators = await async_create_and_refresh_coordinators(
@@ -217,7 +217,7 @@ class TplinkDecoOptionsFlowHandler(config_entries.OptionsFlow):
         self.data = dict(config_entry.data)
         self._errors = {}
 
-    async def async_step_init(self, user_input: dict[str:Any] = None):
+    async def async_step_init(self, user_input: dict[str, Any] = None):
         """Handle a flow initialized by the user."""
         self._errors = {}
 

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -89,7 +89,8 @@ class TpLinkDeco:
 
         self.name = data.get("custom_nickname")  # Only set if custom value
         if self.name is None:
-            self.name = snake_case_to_title_space(data.get("nickname"))
+            nickname = data.get("nickname")
+            self.name = snake_case_to_title_space(nickname) if nickname else self.mac
         self.ip_address = filter_invalid_ip(data.get("device_ip"))
         self.online = data.get("group_status") == "connected"
         inet = data.get("inet_status")
@@ -127,7 +128,7 @@ class TpLinkDecoClient:
 
     def update(
         self,
-        data: dict[str:Any],
+        data: dict[str, Any],
         deco_mac: str,
         utc_point_in_time: datetime,
     ) -> None:
@@ -148,7 +149,7 @@ class TpLinkDecoData:
     def __init__(
         self,
         master_deco: TpLinkDeco = None,
-        decos: dict[str:TpLinkDeco] = None,
+        decos: dict[str, TpLinkDeco] = None,
     ) -> None:
         self.master_deco = master_deco
         self.decos = {} if decos is None else decos
@@ -280,7 +281,7 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         deco_update_coordinator: TplinkDecoUpdateCoordinator,
         consider_home_seconds: int,
         update_interval: timedelta = None,
-        data: dict[str:TpLinkDecoClient] = None,
+        data: dict[str, TpLinkDecoClient] = None,
     ) -> None:
         """Initialize."""
         self.api = api
@@ -305,7 +306,7 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
             return self.data
 
         if len(self._deco_update_coordinator.data.decos) == 0:
-            return
+            return self.data if self.data else {}
 
         old_clients = self.data
         clients = {}

--- a/custom_components/tplink_deco/device_tracker.py
+++ b/custom_components/tplink_deco/device_tracker.py
@@ -255,7 +255,7 @@ class TplinkDecoDeviceTracker(CoordinatorEntity, RestoreEntity, ScannerEntity):
         return self._deco.online
 
     @property
-    def extra_state_attributes(self) -> dict[str:Any]:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         attributes = {
             ATTR_BSSID_BAND2_4: self._deco.bssid_band2_4,
@@ -394,7 +394,7 @@ class TplinkDecoClientDeviceTracker(CoordinatorEntity, RestoreEntity, ScannerEnt
         return self._client.online
 
     @property
-    def extra_state_attributes(self) -> dict[str:Any]:
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         deco = self._coordinator_decos.data.decos.get(self._attr_deco_mac)
         return {


### PR DESCRIPTION
## Summary

Code audit found 8 bugs (some multi-entry only, some edge-case crashes). All fixes are minimal and targeted.

### Bug Fixes

| # | File | Issue | Fix |
|---|------|-------|-----|
| 1 | `__init__.py` | Copy-paste: 2nd refresh validates deco instead of clients coordinator | `clients_coordinator._async_update_data()` |
| 2 | `__init__.py` | Reboot service: `id[0]` on `None` when device has ≠ 1 identifier | Generator finds DOMAIN identifier directly |
| 3 | `__init__.py` | Service closure captures last-loaded coordinator (multi-entry) | Dynamic resolution + duplicate guard |
| 4 | `__init__.py` | `async_forward_entry_setups` via `async_create_task` (racy) | Properly `await`ed |
| 5 | `coordinator.py` | Client coordinator returns `None` when decos == 0 | Returns `self.data` or `{}` |
| 6 | `coordinator.py` | `snake_case_to_title_space(None)` when nickname missing | Fallback to MAC |
| 7 | multiple | `dict[str:Any]` (slice syntax) / `cast([str], ...)` | `dict[str, Any]`, `cast(list[str], ...)` |
| 8 | `api.py` | Cookie regex `[a-f0-9]+` too strict for some firmware | `[a-zA-Z0-9_.-]+` |

### Also
- `manifest.json`: key order corrected for hassfest (`domain`, `name`, then alphabetical)

### Testing
Tested on real TP-Link Deco M4 mesh (4 nodes). No regressions observed.