### PR TITLE
Fix config flow validation and name decoding fallback

### DIFF
--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -44,12 +44,15 @@ def byte_len(n: int) -> int:
 
 
 def decode_name_with_fallback(name: str):
+    """Decode base64 encoded names and fall back to the raw name."""
+    if not name:
+        return name
+
     try:
-        name = base64.b64decode(name)
-        return name.decode()
-    except Exception as err:
-        _LOGGER.warning("Error decoding name %s: %s", name, err)
-        return f"<Error Decoding {name}>"
+        decoded = base64.b64decode(name, validate=True)
+        return decoded.decode("utf-8")
+    except Exception:
+        return name
 
 
 def rsa_encrypt(n: int, e: int, plaintext: bytes) -> bytes:

--- a/custom_components/tplink_deco/config_flow.py
+++ b/custom_components/tplink_deco/config_flow.py
@@ -64,7 +64,10 @@ def _get_schema(data: dict[str:Any]):
             vol.Required(
                 CONF_SCAN_INTERVAL,
                 default=scan_interval,
-            ): vol.In([10, 30, 60, 120]),
+            ): vol.All(
+                vol.Coerce(int),
+                vol.In({10, 30, 60, 120}),
+            ),
             vol.Required(
                 CONF_CONSIDER_HOME,
                 default=data.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME),

--- a/custom_components/tplink_deco/manifest.json
+++ b/custom_components/tplink_deco/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/amosyuen/ha-tplink-deco/issues",
   "loggers": ["tplink_deco"],
   "requirements": ["pycryptodome>=3.12.0"],
-  "version": "3.8.0"
+  "version": "3.8.1"
 }


### PR DESCRIPTION
## Summary

Fixes two small issues found in v3.8.0.

## Changes

### Config flow validation
- Coerce `scan_interval` to int before validating allowed values
- Fixes form submit errors when Home Assistant provides selected values as strings

### Deco name decoding
- Improve name decoding fallback for Deco devices that return plain text names instead of base64 encoded names
- Prevents names like `<Error Decoding garage>` from being generated

## Result

- Polling interval validation is more robust
- Deco names are displayed correctly when the API returns plain text names