### PR TITLE
Fall back to global client_list query when per-node returns 5xx

### DIFF
--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -8,6 +8,8 @@ import ipaddress
 import logging
 from typing import Any
 
+import aiohttp
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
 from homeassistant.core import HomeAssistant
@@ -315,14 +317,31 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         utc_point_in_time = dt_util.utcnow()
         # Send list client requests in parallel for each deco
 
-        deco_client_responses = await asyncio.gather(
-            *[
-                async_call_and_propagate_config_error(
-                    self.api.async_list_clients, deco_mac
-                )
-                for deco_mac in deco_macs
+        try:
+            deco_client_responses = await asyncio.gather(
+                *[
+                    async_call_and_propagate_config_error(
+                        self.api.async_list_clients, deco_mac
+                    )
+                    for deco_mac in deco_macs
+                ]
+            )
+        except aiohttp.ClientResponseError as err:
+            if err.status < 500:
+                raise
+            # Some Deco firmware (e.g. XE75 1.3.x) returns a 5xx (502 observed)
+            # for the per-node client_list query. Fall back to a single global
+            # query and attribute every client to the master Deco, so its
+            # client-count sensor reflects the whole mesh (satellites report 0).
+            _LOGGER.debug(
+                "Per-node client_list failed (%s); falling back to global query",
+                err,
+            )
+            master_deco = self._deco_update_coordinator.data.master_deco
+            deco_macs = [master_deco.mac if master_deco is not None else "default"]
+            deco_client_responses = [
+                await async_call_and_propagate_config_error(self.api.async_list_clients)
             ]
-        )
 
         if len(deco_client_responses) > 0:
             # deco_macs is not subscriptable, must be iterated


### PR DESCRIPTION
## Problem

On some Deco firmware the **per-node** client list query returns a `502 Bad Gateway`:

```
POST /admin/client?form=client_list   params.device_mac=<node-mac>
```

Confirmed on an **XE75 mesh running firmware 1.3.1 (Build 20251023)**. Because `_async_update_data` issues one of these per node via `asyncio.gather`, a single 502 makes the whole client-update cycle raise, and every client `device_tracker` goes unavailable. The **global** query (`device_mac="default"`) keeps working on the same firmware.

## Change

In `TplinkDecoClientUpdateCoordinator._async_update_data`, wrap the per-node `gather` in a `try`/`except aiohttp.ClientResponseError`:

- `status < 500` (auth/config/client errors) → re-raise unchanged, so nothing is masked.
- `status >= 500` (the 502, and other server-side variants of the same firmware bug) → fall back to a **single global query** and attribute every client to the master Deco. The master's connected-clients sensor then reflects the whole mesh and satellites report 0, instead of the integration erroring out.

Normal per-node behavior is untouched on firmware where it works — the fallback only triggers on a 5xx.

## Notes

- No new dependencies; `aiohttp` is already a transitive dep and is now imported in the coordinator.
- `ruff check` (repo `.ruff.toml`) and `ruff format --check` are clean; the file compiles.
- Happy to gate the fallback behind a config option instead if you'd prefer it opt-in.