### PR TITLE
Fix pre-commit formatting after PR #527

### DIFF
--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -9,7 +9,6 @@ import logging
 from typing import Any
 
 import aiohttp
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE
 from homeassistant.core import HomeAssistant


### PR DESCRIPTION
## Summary

Fixes pre-commit formatting after PR #527.

## Changes

- Applies the formatting changes required by pre-commit / isort
- Restores green CI on `main`

## Credits

Formatting fix following PR #527 by @ericmason.