### PR TITLE
Fix config flow polling selector and HA compatibility warnings

### DIFF
--- a/custom_components/tplink_deco/__init__.py
+++ b/custom_components/tplink_deco/__init__.py
@@ -31,6 +31,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 
 from .api import TplinkDecoApi
+from .api import normalize_name
 from .const import ATTR_DEVICE_TYPE
 from .const import CONF_CLIENT_POSTFIX
 from .const import CONF_CLIENT_PREFIX
@@ -145,11 +146,11 @@ async def async_create_config_data(hass: HomeAssistant, config_entry: ConfigEntr
             continue
         if device_type == DEVICE_TYPE_DECO:
             deco = TpLinkDeco(entry.unique_id)
-            deco.name = entry.original_name
+            deco.name = normalize_name(entry.original_name)
             deco_data.decos[entry.unique_id] = deco
         else:
             client = TpLinkDecoClient(entry.unique_id)
-            client.name = entry.original_name
+            client.name = normalize_name(entry.original_name)
             client_data[entry.unique_id] = client
 
     return await async_create_and_refresh_coordinators(

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -37,6 +37,19 @@ MAX_AES_KEY = (10**AES_KEY_BYTES) - 1
 PKCS1_v1_5_HEADER_BYTES = 11
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+LEGACY_ERROR_DECODING_PATTERN = re.compile(r"^<Error Decoding (.*)>$")
+
+
+def normalize_name(name: str):
+    """Normalize Deco/client names from current and legacy decoding behavior."""
+    if not isinstance(name, str) or not name:
+        return name
+
+    match = LEGACY_ERROR_DECODING_PATTERN.match(name)
+    if match:
+        return match.group(1)
+
+    return name
 
 
 def byte_len(n: int) -> int:
@@ -50,9 +63,9 @@ def decode_name_with_fallback(name: str):
 
     try:
         decoded = base64.b64decode(name, validate=True)
-        return decoded.decode("utf-8")
+        return normalize_name(decoded.decode("utf-8"))
     except Exception:
-        return name
+        return normalize_name(name)
 
 
 def rsa_encrypt(n: int, e: int, plaintext: bytes) -> bytes:

--- a/custom_components/tplink_deco/config_flow.py
+++ b/custom_components/tplink_deco/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import selector
 import voluptuous as vol
 
 from .__init__ import async_create_and_refresh_coordinators
@@ -36,6 +37,26 @@ from .const import DOMAIN
 from .exceptions import TimeoutException
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+SCAN_INTERVAL_OPTIONS = [10, 30, 60, 120]
+SCAN_INTERVAL_SELECTOR_OPTIONS = [str(value) for value in SCAN_INTERVAL_OPTIONS]
+
+
+def _get_scan_interval(data: dict[str:Any]) -> str:
+    scan_interval = data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    try:
+        scan_interval = int(scan_interval)
+    except (TypeError, ValueError):
+        scan_interval = DEFAULT_SCAN_INTERVAL
+
+    if scan_interval not in SCAN_INTERVAL_OPTIONS:
+        scan_interval = DEFAULT_SCAN_INTERVAL
+
+    return str(scan_interval)
+
+
+def _normalize_scan_interval(data: dict[str:Any]) -> None:
+    if CONF_SCAN_INTERVAL in data:
+        data[CONF_SCAN_INTERVAL] = int(data[CONF_SCAN_INTERVAL])
 
 
 def _get_auth_schema(data: dict[str:Any]):
@@ -51,10 +72,7 @@ def _get_schema(data: dict[str:Any]):
     if data is None:
         data = {}
     schema = _get_auth_schema(data)
-    scan_interval = data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-
-    if scan_interval not in [10, 30, 60, 120]:
-        scan_interval = DEFAULT_SCAN_INTERVAL
+    scan_interval = _get_scan_interval(data)
 
     schema.update(
         {
@@ -64,9 +82,11 @@ def _get_schema(data: dict[str:Any]):
             vol.Required(
                 CONF_SCAN_INTERVAL,
                 default=scan_interval,
-            ): vol.All(
-                vol.Coerce(int),
-                vol.In({10, 30, 60, 120}),
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=SCAN_INTERVAL_SELECTOR_OPTIONS,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
             ),
             vol.Required(
                 CONF_CONSIDER_HOME,
@@ -163,6 +183,7 @@ class TplinkDecoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
 
         if user_input is not None:
+            _normalize_scan_interval(user_input)
             self._errors = await _async_test_credentials(self.hass, user_input)
             if len(self._errors) == 0:
                 _ensure_user_input_optionals(user_input)
@@ -226,6 +247,7 @@ class TplinkDecoOptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             _ensure_user_input_optionals(user_input)
+            _normalize_scan_interval(user_input)
             self.data.update(user_input)
 
             self._errors = await _async_test_credentials(self.hass, self.data)

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .api import TplinkDecoApi
+from .api import normalize_name
 from .const import DOMAIN
 from .const import SIGNAL_CLIENT_ADDED
 from .const import SIGNAL_DECO_ADDED
@@ -88,9 +89,11 @@ class TpLinkDeco:
         self.sw_version = data.get("software_ver")
         self.device_model = data.get("device_model")
 
-        self.name = data.get("custom_nickname")  # Only set if custom value
+        self.name = normalize_name(
+            data.get("custom_nickname")
+        )  # Only set if custom value
         if self.name is None:
-            self.name = snake_case_to_title_space(data.get("nickname"))
+            self.name = normalize_name(snake_case_to_title_space(data.get("nickname")))
         self.ip_address = filter_invalid_ip(data.get("device_ip"))
         self.online = data.get("group_status") == "connected"
         inet = data.get("inet_status")
@@ -133,7 +136,7 @@ class TpLinkDecoClient:
         utc_point_in_time: datetime,
     ) -> None:
         self.deco_mac = deco_mac
-        self.name = data.get("name")
+        self.name = normalize_name(data.get("name"))
         self.ip_address = filter_invalid_ip(data.get("ip"))
         self.online = data.get("online")
         self.connection_type = data.get("connection_type")

--- a/custom_components/tplink_deco/device_tracker.py
+++ b/custom_components/tplink_deco/device_tracker.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.components.device_tracker import ScannerEntity
 from homeassistant.components.device_tracker.const import ATTR_IP
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
@@ -29,7 +29,6 @@ from .const import ATTR_INTERNET_ONLINE
 from .const import ATTR_MASTER
 from .const import ATTR_SIGNAL_BAND2_4
 from .const import ATTR_SIGNAL_BAND5
-from .const import ATTR_UI_DEVICE_NAME
 from .const import ATTR_UP_KILOBYTES_PER_S
 from .const import CONF_CLIENT_POSTFIX
 from .const import CONF_CLIENT_PREFIX
@@ -49,6 +48,7 @@ from .coordinator import TplinkDecoUpdateCoordinator
 from .device import create_device_info
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+ATTR_UI_DEVICE_NAME = "ui_device_name"
 
 
 def _generate_name(name: str, prefix: str, postfix: str):

--- a/custom_components/tplink_deco/manifest.json
+++ b/custom_components/tplink_deco/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/amosyuen/ha-tplink-deco/issues",
   "loggers": ["tplink_deco"],
   "requirements": ["pycryptodome>=3.12.0"],
-  "version": "3.8.2"
+  "version": "3.9.0"
 }


### PR DESCRIPTION
This PR includes three small fixes:

- Replaces the polling interval radio buttons with a Home Assistant SelectSelector dropdown to avoid the value must be one of [10, 30, 60, 120] error on submit. #524  

- Updates the deprecated ScannerEntity import to homeassistant.components.device_tracker.ScannerEntity #529  #524  

- Normalizes old "<Error Decoding ...>" names back to the original name, so stale Deco/client names no longer remain in sensors or restored data.