### PR TITLE
Fix EmptyDataException on HA 2026.7 when router 307-redirects http to https (aiohttp 3.14 cookie drop)

### DIFF
--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -457,6 +457,26 @@ class TplinkDecoApi:
                 )
                 response.raise_for_status()
 
+                # Some Deco firmwares 307-redirect every http:// request to
+                # https:// on the same host. aiohttp >= 3.14 (HA 2026.7+)
+                # correctly drops per-request cookies on such cross-origin
+                # (scheme-change) redirects per RFC 6265, so the sysauth
+                # cookie never reaches the router and authenticated calls
+                # return empty data. Permanently switch the base URL to
+                # https so subsequent requests skip the redirect entirely.
+                if (
+                    response.history
+                    and response.url.scheme == "https"
+                    and self._host.startswith("http://")
+                    and response.url.host == response.history[0].url.host
+                ):
+                    self._host = "https://" + self._host[len("http://") :]
+                    _LOGGER.warning(
+                        "%s: Router redirected to HTTPS, switching host to %s",
+                        context,
+                        self._host,
+                    )
+
                 # Verbeterde extractie: loop door alle Set-Cookie headers
                 for cookie_header in response.headers.getall(SET_COOKIE, []):
                     match = re.search(r"(sysauth=[a-f0-9]+)", cookie_header)


### PR DESCRIPTION
## Problem

Fixes #538 (recurrence of the April symptom from #491/#493, but with a different root cause).

After updating to Home Assistant Core **2026.7.0**, every polling cycle fails with:

```
custom_components.tplink_deco.exceptions.EmptyDataException: List Devices data is empty
```

## Root cause (bisected and reproduced outside HA)

HA 2026.7 bumped **aiohttp 3.13.5 → 3.14.1**. aiohttp 3.14.0 contains this RFC-6265 compliance fix:

> *Fixed per-request cookies not being dropped on cross-origin redirects*

Some Deco firmwares answer **`307 Temporary Redirect` (http → https, same host) to every request**:

```
$ curl -s -o /dev/null -D - -X POST 'http://192.168.1.1/cgi-bin/luci/;stok=abc/admin/device?form=device_list'
HTTP/1.1 307 Temporary Redirect
Location: https://192.168.1.1/cgi-bin/luci/;stok=abc/admin/device?form=device_list
```

A scheme change is a **different origin**, so on aiohttp ≥ 3.14 the `sysauth` cookie passed via the per-request `cookies=` dict is (correctly) **dropped on the redirect hop**. The router receives every authenticated call without a session and replies with empty `data`, which raises `EmptyDataException`. Login itself still "succeeds" (it doesn't need the cookie), which is why re-login retries don't help.

Verified with a standalone reproduction driving this component's `api.py` against a real Deco X20 mesh (6 units), config host `http://192.168.1.1`:

| aiohttp | host | result |
|---|---|---|
| 3.13.5 (HA 2026.6) | `http://` | ✅ OK — cookie survives redirect (pre-3.14 non-RFC behavior) |
| 3.14.1 (HA 2026.7) | `http://` | ❌ `EmptyDataException: List Devices data is empty` (exact production failure) |
| 3.14.1 (HA 2026.7) | `https://` | ✅ OK — no redirect, no cookie loss |

## Fix

In `_async_post`, detect a same-host `http → https` redirect (`response.history`) and permanently upgrade the configured base URL to `https`. All subsequent requests skip the redirect entirely, so per-request cookies are delivered again. Self-healing, no config change required, works on both aiohttp 3.13 and 3.14, and saves one 307 round-trip per request on affected firmwares. The same-host check prevents rewriting on redirects to a different device.

Tested on the reproduction above (both aiohttp versions, http and https hosts) and deployed on a live HA 2026.7.0 install: entities recovered immediately after restart, with a single warning logged on the first request:

```
Fetch keys: Router redirected to HTTPS, switching host to https://192.168.1.1
```

## Workaround for users (no code change)

Change the integration host from `http://<router-ip>` to `https://<router-ip>` (with SSL verification off). Note the config-flow default is `http://192.168.0.1`, so most installs with https-forcing firmware will hit this bug — hence the code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
