### PR TITLE
Fix platform setup: crash when no master Deco + await forward_entry_setups

### DIFF
--- a/custom_components/tplink_deco/__init__.py
+++ b/custom_components/tplink_deco/__init__.py
@@ -200,9 +200,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     hass.data[DOMAIN][config_entry.entry_id] = data
     deco_coordinator = data[COORDINATOR_DECOS_KEY]
 
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    )
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     async def async_reboot_deco(service: ServiceCall) -> None:
         dr = device_registry.async_get(hass=hass)

--- a/custom_components/tplink_deco/sensor.py
+++ b/custom_components/tplink_deco/sensor.py
@@ -188,10 +188,20 @@ async def async_setup_entry(
         async_add_entities(entities)
 
     tracked_decos = set()
+    total_added = False
 
     @callback
     def add_untracked_deco_sensors():
-        """Add new tracker entities for decos."""
+        """Add new tracker entities for decos (and the total sensors)."""
+        nonlocal total_added
+
+        # The "Total" sensors need the master Deco for their unique id / device.
+        # It may not be known on the first refresh (e.g. a satellite-only entry),
+        # so (re)try adding them whenever decos are discovered.
+        if not total_added and coordinator_decos.data.master_deco is not None:
+            add_sensors_for_deco(None)  # Total sensors
+            total_added = True
+
         for mac, deco in coordinator_decos.data.decos.items():
             if mac in tracked_decos:
                 continue
@@ -202,7 +212,6 @@ async def async_setup_entry(
             add_sensors_for_deco(deco)
             tracked_decos.add(mac)
 
-    add_sensors_for_deco(None)  # Total sensors
     add_untracked_deco_sensors()
 
     coordinator_decos.on_close(


### PR DESCRIPTION
Two small setup-robustness fixes, independent of each other.

### 1. `sensor.py` — crash when a config entry has no master Deco
The "Total" Down/Up sensors build their unique id from
`coordinator.data.master_deco.mac`. On entries where no master Deco is present
(e.g. a satellite-only entry, or before the first refresh identifies a master)
`master_deco` is `None`, and setup crashed with:

AttributeError: 'NoneType' object has no attribute 'mac'

The Total sensors are now deferred until a master Deco is known and (re)tried
on `SIGNAL_DECO_ADDED`, so setup no longer crashes and they still appear once a
master is discovered.

### 2. `__init__.py` — await `async_forward_entry_setups`
`async_forward_entry_setups` was wrapped in `hass.async_create_task(...)`. It is
now awaited directly, per the Home Assistant deprecation warning:

> Detected code that calls async_forward_entry_setups ... during setup without
> awaiting async_forward_entry_setups, which can cause the setup lock to be
> released before the setup is done.

### Testing
Verified on a multi-node Deco mesh where some config entries have no master:
no more `NoneType ... mac` traceback at startup, and the deprecation warning is
gone. Existing behaviour (Total/per-Deco sensors) unchanged when a master is
present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---