### PR TITLE
Add read-only WiFi network status binary sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ Two types of sensors are available:
 
 ---
 
+### WiFi network status
+
+Read-only on/off status sensors for each WiFi network the Deco exposes
+(main / guest / IoT), attached to the master Deco:
+
+- `binary_sensor.<deco>_main_wifi`
+- `binary_sensor.<deco>_guest_wifi`
+- `binary_sensor.<deco>_iot_wifi`
+
+Handy for dashboards, automations and notifications (e.g. alert when the guest
+network is left on). Only the networks present on your model are created.
+
+> **Note:** these are **status only**. Enabling/disabling WiFi is not exposed
+> because some Deco firmwares (e.g. the Deco X50) reject wireless-config writes
+> on the local API (the write handler errors server-side), so writing is not
+> reliably supported.
+
+---
+
 ### Polling Control
 
 #### Runtime control
@@ -105,6 +124,12 @@ Configurable:
 
 - CPU usage (raw + smoothed)
 - Memory usage (raw + smoothed)
+
+### WiFi status
+
+- `binary_sensor.<deco>_main_wifi`
+- `binary_sensor.<deco>_guest_wifi`
+- `binary_sensor.<deco>_iot_wifi`
 
 ---
 

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -133,6 +133,82 @@ def check_data_error_code(context, data):
         raise UnexpectedApiException(f"{context} error_code={error_code}")
 
 
+def _normalize_enable(value) -> bool:
+    """Interpret a Deco enable flag (bool or "on"/"off" string) as a bool."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("on", "true", "1", "enable", "enabled")
+
+
+def _match_key(pattern: str, key: str) -> bool:
+    """Match a config key against a path segment (trailing '*' is a wildcard)."""
+    if pattern.endswith("*"):
+        return str(key).startswith(pattern[:-1])
+    return pattern == key
+
+
+def _resolve_sections(config, paths) -> list:
+    """Return the section dicts reached by following any of the given paths.
+
+    A path is a list of key patterns, e.g. ["band*", "host"] resolves to
+    band2_4.host and band5_1.host. Returned dicts are live references into
+    config, so mutating them mutates config.
+    """
+    sections = []
+    for path in paths:
+        nodes = [config]
+        for pattern in path:
+            next_nodes = []
+            for node in nodes:
+                if isinstance(node, dict):
+                    for key, value in node.items():
+                        if _match_key(pattern, key):
+                            next_nodes.append(value)
+            nodes = next_nodes
+        sections.extend(node for node in nodes if isinstance(node, dict))
+    return sections
+
+
+def wireless_is_enabled(config, paths) -> bool | None:
+    """Return True if any targeted section of a wireless config is enabled.
+
+    Returns None if none of the paths resolve to a section with an "enable"
+    flag (i.e. the network is not present on this Deco model / firmware).
+    """
+    enables = [
+        _normalize_enable(section["enable"])
+        for section in _resolve_sections(config, paths)
+        if "enable" in section
+    ]
+    if not enables:
+        return None
+    return any(enables)
+
+
+# Keys whose values are secrets (SSID / passwords) and must not be logged.
+_WIRELESS_SECRET_KEY_HINTS = ("ssid", "key", "password", "passwd", "psk", "secret")
+
+
+def redact_wireless(config):
+    """Return a deep copy of a wireless config with secret values masked.
+
+    Keeps structure and enable flags so the shape can be shared safely.
+    """
+    if isinstance(config, dict):
+        redacted = {}
+        for key, value in config.items():
+            if isinstance(value, (dict, list)):
+                redacted[key] = redact_wireless(value)
+            elif any(hint in key.lower() for hint in _WIRELESS_SECRET_KEY_HINTS):
+                redacted[key] = "***"
+            else:
+                redacted[key] = value
+        return redacted
+    if isinstance(config, list):
+        return [redact_wireless(item) for item in config]
+    return config
+
+
 class TplinkDecoApi:
     def __init__(
         self,
@@ -163,6 +239,7 @@ class TplinkDecoApi:
         self._sign_rsa_e = None
 
         self._login_future = None
+        self._wireless_read_futures = {}
         self._seq = None
         self._stok = None
         self._cookie = None
@@ -227,6 +304,50 @@ class TplinkDecoApi:
         data = self._decrypt_data(context, response_json["data"])
         check_data_error_code(context, data)
         _LOGGER.debug("Rebooted decos %s", deco_macs)
+
+    # Read the wireless config for a given form (e.g. wlan).
+    # Returns the raw "result" dict as sent by the Deco. Concurrent reads of the
+    # same form (e.g. all WiFi status sensors polling at once) share one request.
+    async def async_get_wireless(self, form: str) -> dict:
+        future = self._wireless_read_futures.get(form)
+        if future is not None:
+            return await future
+
+        future = asyncio.get_running_loop().create_future()
+        self._wireless_read_futures[form] = future
+        try:
+            result = await self._async_call_with_retry(self._async_get_wireless, form)
+            future.set_result(result)
+            return result
+        except Exception as err:
+            future.set_exception(err)
+            raise
+        finally:
+            # Await future to suppress "exception was never retrieved" when no
+            # concurrent caller consumed it.
+            try:
+                await future
+            except Exception:
+                pass
+            self._wireless_read_futures.pop(form, None)
+
+    async def _async_get_wireless(self, form: str) -> dict:
+        await self.async_login_if_needed()
+
+        context = f"Get Wireless {form}"
+        response_json = await self._async_post(
+            context,
+            f"{self._host}/cgi-bin/luci/;stok={self._stok}/admin/wireless",
+            params={"form": form},
+            data=self._encode_payload({"operation": "read"}),
+        )
+
+        data = self._decrypt_data(context, response_json["data"])
+        check_data_error_code(context, data)
+        result = data.get("result", {})
+        # Log the (redacted) structure without leaking SSID/passwords.
+        _LOGGER.debug("%s result=%s", context, redact_wireless(result))
+        return result
 
     # Return performance data (CPU / memory)
     async def async_get_performance(self) -> dict:

--- a/custom_components/tplink_deco/binary_sensor.py
+++ b/custom_components/tplink_deco/binary_sensor.py
@@ -1,18 +1,25 @@
 """Binary sensors for TP-Link Deco."""
 
+import logging
+
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api import wireless_is_enabled
 from .const import COORDINATOR_DECOS_KEY
 from .const import DOMAIN
 from .const import SIGNAL_DECO_ADDED
+from .const import WIFI_NETWORKS
 from .coordinator import TpLinkDeco
 from .coordinator import TplinkDecoUpdateCoordinator
 from .device import create_device_info
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -54,6 +61,33 @@ async def async_setup_entry(
             hass, SIGNAL_DECO_ADDED, add_untracked_deco_binary_sensors
         )
     )
+
+    await _async_add_wifi_binary_sensors(coordinator_decos, async_add_entities)
+
+
+async def _async_add_wifi_binary_sensors(coordinator, async_add_entities) -> None:
+    """Add read-only on/off status sensors for the Deco's WiFi networks.
+
+    Enabling/disabling WiFi is not supported by the Deco local API (the write
+    handler errors server-side), but reading the state works reliably.
+    """
+    # WiFi sensors attach to the master Deco; skip on satellite-only entries.
+    if coordinator.data.master_deco is None:
+        _LOGGER.debug("No master Deco for this entry, skipping WiFi status sensors")
+        return
+
+    try:
+        config = await coordinator.api.async_get_wireless("wlan")
+    except Exception as err:  # noqa: BLE001 - skip sensors, don't fail setup
+        _LOGGER.warning("Could not read wireless config for WiFi sensors: %s", err)
+        return
+
+    entities = []
+    for network in WIFI_NETWORKS:
+        if wireless_is_enabled(config, network["paths"]) is None:
+            continue
+        entities.append(DecoWifiBinarySensor(coordinator, network))
+    async_add_entities(entities)
 
 
 class TplinkDecoInternetOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity):
@@ -145,3 +179,37 @@ class TplinkDecoOnlineBinarySensor(CoordinatorEntity, BinarySensorEntity):
             deco,
             self.coordinator.data.master_deco,
         )
+
+
+class DecoWifiBinarySensor(BinarySensorEntity):
+    """Read-only on/off status of one of the Deco's WiFi networks."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator, network: dict) -> None:
+        self.coordinator = coordinator
+        self._form = network["form"]
+        self._paths = network["paths"]
+        self._attr_name = network["name"]
+        self._attr_icon = network["icon"]
+        self._attr_unique_id = f"tplink_deco_wifi_{network['key']}"
+        self._attr_is_on = None
+
+    @property
+    def device_info(self) -> DeviceInfo | None:
+        """Attach to the master Deco device."""
+        master_deco = self.coordinator.data.master_deco
+        return create_device_info(master_deco, master_deco)
+
+    async def async_update(self) -> None:
+        """Refresh the on/off state from the Deco."""
+        # Respect the polling switch so we don't hit the router while paused.
+        if self.coordinator.paused:
+            return
+        try:
+            config = await self.coordinator.api.async_get_wireless(self._form)
+            self._attr_is_on = wireless_is_enabled(config, self._paths)
+            self._attr_available = self._attr_is_on is not None
+        except Exception as err:  # noqa: BLE001 - keep last state, mark unavailable
+            _LOGGER.debug("Error updating %s WiFi status: %s", self._form, err)
+            self._attr_available = False

--- a/custom_components/tplink_deco/const.py
+++ b/custom_components/tplink_deco/const.py
@@ -19,6 +19,40 @@ DEFAULT_TIMEOUT_SECONDS = 30
 DEVICE_TYPE_CLIENT = "client"
 DEVICE_TYPE_DECO = "deco"
 
+# Wireless networks exposed as read-only on/off status sensors. All three live
+# inside the "wlan" form on the Deco X50 (guest/iot are NOT separate forms).
+# "paths" point at the section(s) whose "enable" flag we read, relative to the
+# wlan result:
+#   main  -> band2_4.host / band5_1.host
+#   guest -> band2_4.guest / band5_1.guest
+#   iot   -> iot.host
+# "band*" is a trailing-wildcard match so both 2.4G and 5G bands are covered.
+# NOTE: enabling/disabling is not possible on the X50 firmware (the wireless
+# write handler errors server-side), so these are status-only.
+WIFI_NETWORKS = [
+    {
+        "key": "main",
+        "form": "wlan",
+        "name": "Main WiFi",
+        "icon": "mdi:wifi",
+        "paths": [["band*", "host"]],
+    },
+    {
+        "key": "guest",
+        "form": "wlan",
+        "name": "Guest WiFi",
+        "icon": "mdi:wifi-lock-open",
+        "paths": [["band*", "guest"]],
+    },
+    {
+        "key": "iot",
+        "form": "wlan",
+        "name": "IoT WiFi",
+        "icon": "mdi:home-automation",
+        "paths": [["iot", "host"]],
+    },
+]
+
 # Attributes
 ATTR_BSSID_BAND2_4 = "bssid_band2_4"
 ATTR_BSSID_BAND5 = "bssid_band5"


### PR DESCRIPTION
Adds read-only `binary_sensor` entities reflecting the on/off state of each
WiFi network the Deco exposes — **main / guest / IoT** — attached to the master
Deco.

### What
- State is read from `admin/wireless?form=wlan` and mapped via configurable
  paths (`band*/host`, `band*/guest`, `iot/host`), so both 2.4 GHz and 5 GHz
  bands are covered.
- Only the networks actually present on the model are created.
- Concurrent reads of the same form are de-duplicated, so all WiFi sensors
  share a single request per poll cycle.
- Respects the existing `switch.deco_polling` pause.
- SSID/passwords are never logged (redacted in debug output).
- README updated (Features + Entities).

### Why read-only (no enable/disable)
I attempted a write path (`operation: write` on `admin/wireless?form=wlan`), but
on the Deco X50 firmware the write handler crashes server-side, returning
HTTP 500 with an (encrypted) body that decrypts to a Lua error:

attempt to index global 'mode' (a nil value)  ... in function 'dispatch'

This happens **regardless of the request content** — verified with minimal and
full params, `mode` placed in params / URL query / top-level payload, all bands,
all mesh nodes (including the master), and multiple `operation` values (only
`read` and `write` are valid callbacks). The widely-used `tplinkrouterc6u`
library's `set_wifi` sends a byte-equivalent request, so it would hit the same
crash on this firmware. Reading state, however, works reliably — hence
status-only sensors. If a future firmware fixes the write handler, a write path
can be layered on top.

### Note on the diff
`binary_sensor.py` was the only CRLF file in the repo (against the repo's own
`.gitattributes eol=lf`); editing it re-normalizes it to LF, which adds
line-ending noise to the diff. The actual change is additions only —
`git diff --ignore-cr-at-eol` shows +248.

### Testing
Verified on a Deco X50: the three sensors appear on the master Deco and report
the correct on/off state for main / guest / IoT. `binary_sensor` platform was
already registered; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---