### PR TITLE
Fix client query timeout storms on multi-node meshes

### DIFF
--- a/custom_components/tplink_deco/__init__.py
+++ b/custom_components/tplink_deco/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.const import CONF_PASSWORD
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.core import ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers import restore_state
@@ -107,7 +108,16 @@ async def async_create_and_refresh_coordinators(
     if config_entry is None:
         await deco_coordinator._async_update_data()
     else:
-        await clients_coordinator.async_config_entry_first_refresh()
+        try:
+            await clients_coordinator.async_config_entry_first_refresh()
+        except ConfigEntryNotReady as err:
+            # Client-list endpoints are unreliable on some Deco firmware. Keep
+            # the integration available and let the coordinator retry later.
+            _LOGGER.warning(
+                "Client data unavailable during setup; continuing without a "
+                "client refresh: %s",
+                err,
+            )
 
     return {
         COORDINATOR_DECOS_KEY: deco_coordinator,

--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -129,7 +129,7 @@ def check_data_error_code(context, data):
         if error_code == "timeout":
             raise TimeoutException(f'{context} response error_code="timeout"')
 
-        _LOGGER.debug("%s error_code=%s, data=%s", context, error_code, data)
+        _LOGGER.debug("%s error_code=%s", context, error_code)
         raise UnexpectedApiException(f"{context} error_code={error_code}")
 
 
@@ -194,7 +194,6 @@ class TplinkDecoApi:
         try:
             device_list = data["result"]["device_list"]
             _LOGGER.debug("List devices device_count=%d", len(device_list))
-            _LOGGER.debug("List devices device_list=%s", device_list)
 
             for device in device_list:
                 custom_nickname = device.get("custom_nickname")
@@ -205,7 +204,7 @@ class TplinkDecoApi:
 
             return device_list
         except Exception as err:
-            _LOGGER.error("%s parse response error=%s, data=%s", context, err, data)
+            _LOGGER.error("%s parse response error=%s", context, err)
             raise err
 
     # Reboot decos.
@@ -250,8 +249,14 @@ class TplinkDecoApi:
         return data
 
     # Return list of clients. Default lists clients for all decos.
-    async def async_list_clients(self, deco_mac="default") -> dict:
-        return await self._async_call_with_retry(self._async_list_clients, deco_mac)
+    async def async_list_clients(
+        self, deco_mac="default", timeout_error_retries: int | None = None
+    ) -> dict:
+        return await self._async_call_with_retry(
+            self._async_list_clients,
+            deco_mac,
+            timeout_error_retries=timeout_error_retries,
+        )
 
     async def _async_list_clients(self, deco_mac) -> dict:
         await self.async_login_if_needed()
@@ -272,14 +277,13 @@ class TplinkDecoApi:
             client_list = data["result"]["client_list"]
             # client_list is only the connected clients
             _LOGGER.debug("%s client_count=%d", context, len(client_list))
-            _LOGGER.debug("%s client_list=%s", context, client_list)
 
             for client in client_list:
                 client["name"] = decode_name_with_fallback(client["name"])
 
             return client_list
         except Exception as err:
-            _LOGGER.error("%s parse response error=%s, data=%s", context, err, data)
+            _LOGGER.error("%s parse response error=%s", context, err)
             raise err
 
     def _generate_aes_key_and_iv(self):
@@ -288,8 +292,7 @@ class TplinkDecoApi:
         self._aes_iv = secrets.randbelow(MAX_AES_KEY - MIN_AES_KEY) + MIN_AES_KEY
         self._aes_key_bytes = str(self._aes_key).encode("utf-8")
         self._aes_iv_bytes = str(self._aes_iv).encode("utf-8")
-        _LOGGER.debug("aes_key=%s", self._aes_key)
-        _LOGGER.debug("aes_iv=%s", self._aes_iv)
+        _LOGGER.debug("Generated login encryption values")
 
     # Fetch password RSA keys
     async def _async_fetch_keys(self):
@@ -305,15 +308,9 @@ class TplinkDecoApi:
             keys = response_json["result"]["password"]
             self._password_rsa_n = int(keys[0], 16)
             self._password_rsa_e = int(keys[1], 16)
-            _LOGGER.debug("password_rsa_n=%s", self._password_rsa_n)
-            _LOGGER.debug("password_rsa_e=%s", self._password_rsa_e)
+            _LOGGER.debug("Fetched password encryption key")
         except Exception as err:
-            _LOGGER.error(
-                "%s parse response error=%s, response_json=%s",
-                context,
-                err,
-                response_json,
-            )
+            _LOGGER.error("%s parse response error=%s", context, err)
             raise err
 
     # Fetch sign RSA keys and seq no
@@ -330,19 +327,12 @@ class TplinkDecoApi:
             auth_result = response_json["result"]
             auth_key = auth_result["key"]
             self._sign_rsa_n = int(auth_key[0], 16)
-            _LOGGER.debug("sign_rsa_n=%s", self._sign_rsa_n)
             self._sign_rsa_e = int(auth_key[1], 16)
-            _LOGGER.debug("sign_rsa_e=%s", self._sign_rsa_e)
 
             self._seq = auth_result["seq"]
-            _LOGGER.debug("seq=%s", self._seq)
+            _LOGGER.debug("Fetched request signing key")
         except Exception as err:
-            _LOGGER.error(
-                "%s parse response error=%s, response_json=%s",
-                context,
-                err,
-                response_json,
-            )
+            _LOGGER.error("%s parse response error=%s", context, err)
             raise err
 
     async def async_login_if_needed(self):
@@ -414,9 +404,8 @@ class TplinkDecoApi:
 
         try:
             self._stok = result["stok"]
-            _LOGGER.debug("stok=%s", self._stok)
         except Exception as err:
-            _LOGGER.error("%s parse response error=%s, data=%s", context, err, data)
+            _LOGGER.error("%s parse response error=%s", context, err)
             raise UnexpectedApiException from err
 
         if self._cookie is None:
@@ -426,6 +415,7 @@ class TplinkDecoApi:
 
         # Login success
         self._auth_errors = 0
+        _LOGGER.debug("Login successful")
 
     async def _async_post(
         self,
@@ -444,7 +434,7 @@ class TplinkDecoApi:
                 if len(cookie_parts) == 2:
                     request_cookies[cookie_parts[0]] = cookie_parts[1]
             except Exception:
-                _LOGGER.warning("Could not parse cookie: %s", self._cookie)
+                _LOGGER.warning("Could not parse session cookie")
         try:
             async with async_timeout.timeout(self._timeout_seconds):
                 response = await self._session.post(
@@ -482,7 +472,7 @@ class TplinkDecoApi:
                     match = re.search(r"(sysauth=[a-f0-9]+)", cookie_header)
                     if match:
                         self._cookie = match.group(1)
-                        _LOGGER.debug("Found new cookie: %s", self._cookie)
+                        _LOGGER.debug("Received new session cookie")
                         break
 
                 # Soms antwoordt de server met de verkeerde content-type
@@ -491,10 +481,9 @@ class TplinkDecoApi:
                     error_code = response_json.get("error_code")
                     if error_code != 0 and error_code != "":
                         _LOGGER.debug(
-                            "%s error_code=%s, response_json=%s",
+                            "%s error_code=%s",
                             context,
                             error_code,
-                            response_json,
                         )
                         raise UnexpectedApiException(f"{context} error: {error_code}")
 
@@ -590,17 +579,19 @@ class TplinkDecoApi:
             data_json = json.loads(data_decrypted)
             return data_json
         except Exception as err:
-            _LOGGER.error(
-                "%s decode data error=%s, data=%s",
-                context,
-                err,
-                data,
-            )
+            _LOGGER.error("%s decode data error=%s", context, err)
             raise err
 
-    async def _async_call_with_retry(self, func, *args):
+    async def _async_call_with_retry(
+        self, func, *args, timeout_error_retries: int | None = None
+    ):
         relogin_retried = False
         timeout_retries = 0
+        max_timeout_retries = (
+            self._timeout_error_retries
+            if timeout_error_retries is None
+            else timeout_error_retries
+        )
         while True:
             try:
                 return await func(*args)
@@ -614,13 +605,13 @@ class TplinkDecoApi:
                     err,
                 )
             except TimeoutException as err:
-                if timeout_retries >= self._timeout_error_retries:
+                if timeout_retries >= max_timeout_retries:
                     # Reached max retries
                     raise err
                 timeout_retries += 1
                 _LOGGER.debug(
                     "Retry (%d of %d) timeout error: %s",
                     timeout_retries,
-                    self._timeout_error_retries,
+                    max_timeout_retries,
                     err,
                 )

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -25,8 +25,10 @@ from .const import SIGNAL_CLIENT_ADDED
 from .const import SIGNAL_DECO_ADDED
 from .exceptions import LoginForbiddenException
 from .exceptions import LoginInvalidException
+from .exceptions import TimeoutException
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+MAX_CONCURRENT_CLIENT_REQUESTS = 2
 
 
 def bytes_to_bits(bytes_count):
@@ -46,9 +48,9 @@ def snake_case_to_title_space(str):
     return " ".join([w.title() for w in str.split("_")])
 
 
-async def async_call_and_propagate_config_error(func, *args):
+async def async_call_and_propagate_config_error(func, *args, **kwargs):
     try:
-        return await func(*args)
+        return await func(*args, **kwargs)
     except (LoginForbiddenException, LoginInvalidException) as err:
         raise ConfigEntryAuthFailed from err
 
@@ -302,6 +304,28 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         # Must happen after super().__init__
         self.data = {} if data is None else data
 
+    async def _async_list_clients_per_deco(self, deco_macs: list[str]):
+        """List clients with bounded concurrency and no per-node timeout retries."""
+        semaphore = asyncio.Semaphore(MAX_CONCURRENT_CLIENT_REQUESTS)
+
+        async def async_list_clients(deco_mac: str):
+            async with semaphore:
+                return await async_call_and_propagate_config_error(
+                    self.api.async_list_clients,
+                    deco_mac,
+                    timeout_error_retries=0,
+                )
+
+        tasks = [asyncio.create_task(async_list_clients(mac)) for mac in deco_macs]
+        try:
+            return await asyncio.gather(*tasks)
+        except (Exception, asyncio.CancelledError):
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+
     async def _async_update_data(self):
         """Update data via api."""
         if self._deco_update_coordinator.paused:
@@ -315,26 +339,16 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         clients = {}
         client_added = False
         # List clients for all decos if _deco_update_coordinator is not provided
-        deco_macs = self._deco_update_coordinator.data.decos.keys()
+        deco_macs = list(self._deco_update_coordinator.data.decos)
         utc_point_in_time = dt_util.utcnow()
-        # Send list client requests in parallel for each deco
 
         try:
-            deco_client_responses = await asyncio.gather(
-                *[
-                    async_call_and_propagate_config_error(
-                        self.api.async_list_clients, deco_mac
-                    )
-                    for deco_mac in deco_macs
-                ]
-            )
-        except aiohttp.ClientResponseError as err:
-            if err.status < 500:
+            deco_client_responses = await self._async_list_clients_per_deco(deco_macs)
+        except (aiohttp.ClientResponseError, TimeoutException) as err:
+            if isinstance(err, aiohttp.ClientResponseError) and err.status < 500:
                 raise
-            # Some Deco firmware (e.g. XE75 1.3.x) returns a 5xx (502 observed)
-            # for the per-node client_list query. Fall back to a single global
-            # query and attribute every client to the master Deco, so its
-            # client-count sensor reflects the whole mesh (satellites report 0).
+            # Some Deco firmware times out or returns 5xx for per-node client
+            # queries. Fall back to one global query to avoid a retry storm.
             _LOGGER.debug(
                 "Per-node client_list failed (%s); falling back to global query",
                 err,

--- a/custom_components/tplink_deco/manifest.json
+++ b/custom_components/tplink_deco/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/amosyuen/ha-tplink-deco/issues",
   "loggers": ["tplink_deco"],
   "requirements": ["pycryptodome>=3.12.0"],
-  "version": "3.9.4"
+  "version": "3.9.5"
 }


### PR DESCRIPTION
#555 
## Summary

- Limit per-node client queries to two concurrent requests.
- Disable retries for individual node queries.
- Fall back to one global client query after a timeout or server error.
- Allow integration setup to continue when client data is temporarily unavailable.
- Remove sensitive values and device details from debug logging.

This prevents large Deco meshes from generating synchronized retry storms that can cause repeated timeouts and temporary authentication failures.

Existing configuration entries, entities, polling intervals, and successful per-node behavior remain unchanged.

## Testing

- Python compilation passed.
- `git diff --check` passed.
- Home Assistant testing on affected Deco firmware is recommended.