### PR TITLE
Fix login timeout: send cookie as raw header instead of aiohttp cookies param

### DIFF
--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -433,16 +433,8 @@ class TplinkDecoApi:
         data: Any,
     ) -> dict:
         headers = {CONTENT_TYPE: "application/json"}
-        # Gebruik een dictionary voor cookies in plaats van een string in headers
-        request_cookies = {}
         if self._cookie is not None:
-            try:
-                # Split 'sysauth=abc' naar {'sysauth': 'abc'}
-                cookie_parts = self._cookie.split("=", 1)
-                if len(cookie_parts) == 2:
-                    request_cookies[cookie_parts[0]] = cookie_parts[1]
-            except Exception:
-                _LOGGER.warning("Could not parse session cookie")
+            headers["Cookie"] = self._cookie
         try:
             async with async_timeout.timeout(self._timeout_seconds):
                 response = await self._session.post(
@@ -450,7 +442,6 @@ class TplinkDecoApi:
                     params=params,
                     data=data,
                     headers=headers,
-                    cookies=request_cookies,  # Gebruik de cookies parameter
                     ssl=self._ssl_context,
                 )
                 response.raise_for_status()


### PR DESCRIPTION
## Problem

When adding the tplink_deco integration (or after a power cycle), the config flow hangs for 30 seconds and times out. Debug logs show:
- Login succeeds (3 POSTs to /login in <1s)
- Device list POST (/admin/device) hangs for exactly 30s and times out

## Root Cause

The integration uses aiohttp's `cookies=` parameter to send the session cookie:

```python
response = await self._session.post(
    url,
    params=params,
    data=data,
    headers=headers,
    cookies=request_cookies,  # aiohttp merges with session CookieJar
    ssl=self._ssl_context,
)
```

aiohttp merges `cookies=` with the session's `CookieJar`, which can send stale or conflicting cookies. The Deco router sees unexpected cookies and either:
- Returns empty data (causing a decode error)
- Hangs waiting for a valid request

The working `tplink-deco-api` library sends the cookie as a raw `Cookie:` header string with no CookieJar interaction:

```python
request = urllib.request.Request(url, method="POST", data=payload)
request.add_header("Cookie", cookie)  # raw header, no jar
```

## Fix

Send the cookie as a raw `Cookie:` header string instead of using aiohttp's `cookies=` parameter. This aligns the integration's HTTP transport with the library the maintainer already recommends.

### Changes

**`api.py`** — `_async_post()` method:
- Remove `request_cookies` dict construction and `cookies=request_cookies` parameter
- Add `headers["Cookie"] = self._cookie` when cookie is set

## Testing

Confirmed working on HA 2026.8.2 with:
- TP-Link Deco XE75 (hardware v2.0, firmware 1.5.0)
- aiohttp 3.14.3
- tplink-deco-api 1.2.2 (for comparison)

Before fix: config flow times out after 30s
After fix: config flow completes successfully, all devices discovered