### PR TITLE
Add integration health diagnostic sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This integration provides local polling control and diagnostics for TP-Link Deco
 - CPU usage (raw + smoothed)
 - Memory usage (raw + smoothed)
 - Backhaul and network diagnostics
+- Coordinator health (last successful update, response time, timeouts, query mode,
+  and last error)
 
 ### CPU / Memory sensors
 

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -1,10 +1,12 @@
 """TP-Link Deco Coordinator"""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from datetime import timedelta
 import ipaddress
 import logging
+from time import monotonic
 from typing import Any
 
 import aiohttp
@@ -27,6 +29,31 @@ from .exceptions import LoginInvalidException
 from .exceptions import TimeoutException
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CoordinatorHealth:
+    """Runtime health details for a coordinator."""
+
+    last_successful_update: datetime | None = None
+    response_time_ms: int | None = None
+    timeout_count: int = 0
+    consecutive_failures: int = 0
+    last_error: str = "0"
+
+    def record_success(self, started: float) -> None:
+        """Record a successful coordinator update."""
+        self.last_successful_update = dt_util.utcnow()
+        self.response_time_ms = round((monotonic() - started) * 1000)
+        self.consecutive_failures = 0
+
+    def record_failure(self, started: float, err: Exception) -> None:
+        """Record a failed coordinator update without exposing response data."""
+        self.response_time_ms = round((monotonic() - started) * 1000)
+        self.consecutive_failures += 1
+        self.last_error = type(err).__name__
+        if isinstance(err, TimeoutException):
+            self.timeout_count += 1
 
 
 def bytes_to_bits(bytes_count):
@@ -184,12 +211,26 @@ class TplinkDecoUpdateCoordinator(DataUpdateCoordinator):
         self.data = TpLinkDecoData() if data is None else data
 
         self.paused = False
+        self.health = CoordinatorHealth()
 
     async def _async_update_data(self):
         """Update data via api."""
         if self.paused:
             _LOGGER.debug("Deco polling is paused")
             return self.data
+
+        started = monotonic()
+        try:
+            data = await self._async_update_data_internal()
+        except Exception as err:
+            self.health.record_failure(started, err)
+            raise
+
+        self.health.record_success(started)
+        return data
+
+    async def _async_update_data_internal(self):
+        """Fetch and process Deco data."""
 
         new_decos = await async_call_and_propagate_config_error(
             self.api.async_list_devices
@@ -303,6 +344,12 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         self.data = {} if data is None else data
         self.has_successful_refresh = False
         self._use_global_client_query = False
+        self.health = CoordinatorHealth()
+
+    @property
+    def client_query_mode(self) -> str:
+        """Return the client query strategy currently in use."""
+        return "global_fallback" if self._use_global_client_query else "per_node"
 
     async def _async_list_clients_per_deco(self, deco_macs: list[str]):
         """List clients sequentially without per-node timeout retries."""
@@ -336,7 +383,20 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
             return self.data
 
         if len(self._deco_update_coordinator.data.decos) == 0:
-            return
+            return self.data
+
+        started = monotonic()
+        try:
+            data = await self._async_update_data_internal()
+        except Exception as err:
+            self.health.record_failure(started, err)
+            raise
+
+        self.health.record_success(started)
+        return data
+
+    async def _async_update_data_internal(self):
+        """Fetch and process client data."""
 
         old_clients = self.data
         clients = {}
@@ -355,6 +415,8 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
             except (aiohttp.ClientResponseError, TimeoutException) as err:
                 if isinstance(err, aiohttp.ClientResponseError) and err.status < 500:
                     raise
+                if isinstance(err, TimeoutException):
+                    self.health.timeout_count += 1
                 # Some Deco firmware times out or returns 5xx for per-node
                 # client queries. Use one global query for subsequent updates.
                 self._use_global_client_query = True

--- a/custom_components/tplink_deco/diagnostics.py
+++ b/custom_components/tplink_deco/diagnostics.py
@@ -36,8 +36,18 @@ TO_REDACT = {
 def _coordinator_diagnostics(coordinator) -> dict[str, Any]:
     """Return non-sensitive coordinator state."""
     update_interval = coordinator.update_interval
+    health = coordinator.health
     return {
         "last_update_success": coordinator.last_update_success,
+        "last_successful_update": (
+            health.last_successful_update.isoformat()
+            if health.last_successful_update is not None
+            else None
+        ),
+        "response_time_ms": health.response_time_ms,
+        "timeout_count": health.timeout_count,
+        "consecutive_failures": health.consecutive_failures,
+        "last_error": health.last_error,
         "update_interval_seconds": (
             update_interval.total_seconds() if update_interval is not None else None
         ),
@@ -119,6 +129,7 @@ async def async_get_config_entry_diagnostics(
         },
         "client_coordinator": {
             **_coordinator_diagnostics(client_coordinator),
+            "query_mode": client_coordinator.client_query_mode,
             "clients": [
                 _client_diagnostics(client, f"client_{index}", deco_ids)
                 for index, (_, client) in enumerate(clients, 1)

--- a/custom_components/tplink_deco/manifest.json
+++ b/custom_components/tplink_deco/manifest.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "domain": "tplink_deco",
   "name": "TP-Link Deco",
   "codeowners": ["@amosyuen"],

--- a/custom_components/tplink_deco/manifest.json
+++ b/custom_components/tplink_deco/manifest.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "domain": "tplink_deco",
   "name": "TP-Link Deco",
   "codeowners": ["@amosyuen"],
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/amosyuen/ha-tplink-deco/issues",
   "loggers": ["tplink_deco"],
   "requirements": ["pycryptodome>=3.12.0"],
-  "version": "3.9.10"
+  "version": "3.10.0"
 }

--- a/custom_components/tplink_deco/sensor.py
+++ b/custom_components/tplink_deco/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor.const import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.const import UnitOfDataRate
+from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -35,6 +36,14 @@ class TplinkDecoDiagnosticSensorDescription(SensorEntityDescription):
     """Description of a TP-Link Deco diagnostic sensor."""
 
     value_fn: Callable[[TpLinkDeco], Any]
+
+
+@dataclass(frozen=True, kw_only=True)
+class TplinkCoordinatorHealthSensorDescription(SensorEntityDescription):
+    """Description of a coordinator health sensor."""
+
+    coordinator_key: str
+    value_fn: Callable[[Any], Any]
 
 
 DIAGNOSTIC_SENSOR_DESCRIPTIONS: tuple[TplinkDecoDiagnosticSensorDescription, ...] = (
@@ -125,6 +134,84 @@ DIAGNOSTIC_SENSOR_DESCRIPTIONS: tuple[TplinkDecoDiagnosticSensorDescription, ...
 )
 
 
+COORDINATOR_HEALTH_SENSOR_DESCRIPTIONS: tuple[
+    TplinkCoordinatorHealthSensorDescription, ...
+] = (
+    TplinkCoordinatorHealthSensorDescription(
+        key="deco_last_successful_update",
+        name="Deco last successful update",
+        coordinator_key=COORDINATOR_DECOS_KEY,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda coordinator: coordinator.health.last_successful_update,
+    ),
+    TplinkCoordinatorHealthSensorDescription(
+        key="deco_response_time",
+        name="Deco API response time",
+        coordinator_key=COORDINATOR_DECOS_KEY,
+        device_class=SensorDeviceClass.DURATION,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda coordinator: coordinator.health.response_time_ms,
+    ),
+    TplinkCoordinatorHealthSensorDescription(
+        key="deco_last_error",
+        name="Deco last error",
+        coordinator_key=COORDINATOR_DECOS_KEY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda coordinator: coordinator.health.last_error,
+    ),
+    TplinkCoordinatorHealthSensorDescription(
+        key="client_last_successful_update",
+        name="Client last successful update",
+        coordinator_key=COORDINATOR_CLIENTS_KEY,
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda coordinator: coordinator.health.last_successful_update,
+    ),
+    TplinkCoordinatorHealthSensorDescription(
+        key="client_response_time",
+        name="Client API response time",
+        coordinator_key=COORDINATOR_CLIENTS_KEY,
+        device_class=SensorDeviceClass.DURATION,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfTime.MILLISECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda coordinator: coordinator.health.response_time_ms,
+    ),
+    TplinkCoordinatorHealthSensorDescription(
+        key="client_timeout_count",
+        name="Client timeouts",
+        coordinator_key=COORDINATOR_CLIENTS_KEY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda coordinator: coordinator.health.timeout_count,
+    ),
+    TplinkCoordinatorHealthSensorDescription(
+        key="client_query_mode",
+        name="Client query mode",
+        coordinator_key=COORDINATOR_CLIENTS_KEY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda coordinator: coordinator.client_query_mode,
+    ),
+    TplinkCoordinatorHealthSensorDescription(
+        key="client_last_error",
+        name="Client last error",
+        coordinator_key=COORDINATOR_CLIENTS_KEY,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda coordinator: coordinator.health.last_error,
+    ),
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ):
@@ -193,6 +280,16 @@ async def async_setup_entry(
         # so (re)try adding them whenever decos are discovered.
         if not total_added and coordinator_decos.data.master_deco is not None:
             add_sensors_for_deco(None)  # Total sensors
+            master_deco = coordinator_decos.data.master_deco
+            async_add_entities(
+                TplinkCoordinatorHealthSensor(
+                    coordinator_decos,
+                    data[description.coordinator_key],
+                    master_deco.mac,
+                    description,
+                )
+                for description in COORDINATOR_HEALTH_SENSOR_DESCRIPTIONS
+            )
             total_added = True
 
         for mac, deco in coordinator_decos.data.decos.items():
@@ -374,3 +471,39 @@ class TplinkDecoDiagnosticSensor(CoordinatorEntity, SensorEntity):
         if value is None or value == "" or value == []:
             return None
         return value
+
+
+class TplinkCoordinatorHealthSensor(CoordinatorEntity, SensorEntity):
+    """TP-Link Deco coordinator health sensor entity."""
+
+    entity_description: TplinkCoordinatorHealthSensorDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator_decos: TplinkDecoUpdateCoordinator,
+        coordinator,
+        master_deco_mac: str,
+        description: TplinkCoordinatorHealthSensorDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self._coordinator_decos = coordinator_decos
+        self._master_deco_mac = master_deco_mac
+        self.entity_description = description
+        self._attr_unique_id = f"{master_deco_mac}_{description.key}"
+
+    @property
+    def available(self) -> bool:
+        """Keep health diagnostics available when an update fails."""
+        return True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the master Deco."""
+        master_deco = self._coordinator_decos.data.decos[self._master_deco_mac]
+        return create_device_info(master_deco, master_deco)
+
+    @property
+    def native_value(self):
+        """Return the current coordinator health value."""
+        return self.entity_description.value_fn(self.coordinator)


### PR DESCRIPTION
## Summary

Adds integration health diagnostics for the Deco and client coordinators without introducing additional API requests.

## Changes

- Add diagnostic sensors for the last successful Deco and client updates
- Add Deco and client API response-time sensors
- Add client timeout counter
- Show whether client polling uses per-node queries or the global fallback
- Add last-error sensors for both coordinators
- Show `0` when no coordinator error has occurred
- Include coordinator health information in downloaded diagnostics
- Disable the new diagnostic entities by default to avoid clutter
- Update the integration documentation
- Bump the integration version to 3.10.0

## Compatibility

- Existing configurations and entity unique IDs remain unchanged
- No additional requests are sent to the Deco
- Existing polling and fallback behavior is unchanged

## Testing

- pre-commit passed
- Black passed
- Flake8 passed
- isort passed
- Prettier passed
- Python compilation passed
- Tested in Home Assistant