### PR TITLE
Improve resilience of Deco client polling

### DIFF
--- a/custom_components/tplink_deco/api.py
+++ b/custom_components/tplink_deco/api.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import math
+import random
 import re
 import secrets
 from typing import Any
@@ -38,6 +39,10 @@ PKCS1_v1_5_HEADER_BYTES = 11
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 LEGACY_ERROR_DECODING_PATTERN = re.compile(r"^<Error Decoding (.*)>$")
+
+RETRY_BACKOFF_BASE_SECONDS = 0.25
+RETRY_BACKOFF_MAX_SECONDS = 2.0
+RETRY_BACKOFF_JITTER_SECONDS = 0.1
 
 
 def normalize_name(name: str):
@@ -617,9 +622,16 @@ class TplinkDecoApi:
                     # Reached max retries
                     raise err
                 timeout_retries += 1
+                delay = min(
+                    RETRY_BACKOFF_BASE_SECONDS * (2 ** (timeout_retries - 1)),
+                    RETRY_BACKOFF_MAX_SECONDS,
+                )
+                delay += random.uniform(0, RETRY_BACKOFF_JITTER_SECONDS)
                 _LOGGER.debug(
-                    "Retry (%d of %d) timeout error: %s",
+                    "Retry (%d of %d) timeout error in %.2fs: %s",
                     timeout_retries,
                     max_timeout_retries,
+                    delay,
                     err,
                 )
+                await asyncio.sleep(delay)

--- a/custom_components/tplink_deco/coordinator.py
+++ b/custom_components/tplink_deco/coordinator.py
@@ -46,6 +46,7 @@ class CoordinatorHealth:
         self.last_successful_update = dt_util.utcnow()
         self.response_time_ms = round((monotonic() - started) * 1000)
         self.consecutive_failures = 0
+        self.last_error = "0"
 
     def record_failure(self, started: float, err: Exception) -> None:
         """Record a failed coordinator update without exposing response data."""
@@ -352,26 +353,24 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
         return "global_fallback" if self._use_global_client_query else "per_node"
 
     async def _async_list_clients_per_deco(self, deco_macs: list[str]):
-        """List clients sequentially without per-node timeout retries."""
+        """List clients sequentially, using the API's configured retries."""
         responses = []
         for deco_mac in deco_macs:
             responses.append(
                 await async_call_and_propagate_config_error(
                     self.api.async_list_clients,
                     deco_mac,
-                    timeout_error_retries=0,
                 )
             )
         return responses
 
     async def _async_list_clients_global(self):
-        """List all clients once without timeout retries."""
+        """List all clients using the API's configured timeout retries."""
         master_deco = self._deco_update_coordinator.data.master_deco
         deco_macs = [master_deco.mac if master_deco is not None else "default"]
         responses = [
             await async_call_and_propagate_config_error(
                 self.api.async_list_clients,
-                timeout_error_retries=0,
             )
         ]
         return deco_macs, responses
@@ -390,6 +389,16 @@ class TplinkDecoClientUpdateCoordinator(DataUpdateCoordinator):
             data = await self._async_update_data_internal()
         except Exception as err:
             self.health.record_failure(started, err)
+            if self.has_successful_refresh and not isinstance(
+                err, ConfigEntryAuthFailed
+            ):
+                # A failed response is not evidence that clients are offline. Keep
+                # their last activity timestamps so consider_home is not applied.
+                _LOGGER.warning(
+                    "Client refresh failed; retaining last successful client data: %s",
+                    type(err).__name__,
+                )
+                return self.data
             raise
 
         self.health.record_success(started)


### PR DESCRIPTION
## Summary

Transient `client_list` timeouts and 5xx responses can currently make all client entities unavailable or cause presence-state flapping.

This PR:
- honors the configured timeout retry count for per-node and global client queries;
- adds bounded exponential backoff with jitter between timeout retries;
- preserves the existing per-node to global fallback;
- retains the last successful client data after a failed refresh, without applying `consider_home` to an unsuccessful response;
- preserves authentication failure propagation and records degraded refresh health.

## Validation

- Python compilation passed.
- Black, flake8, and repository pre-commit checks passed except isort.
- isort is currently incompatible with the repository configuration (`not_skip` is unsupported by the installed version).
- The repository contains no test suite, and pytest is not installed in the environment.